### PR TITLE
Replace internal camera motion detection with a custom implementation

### DIFF
--- a/HOW_TO.md
+++ b/HOW_TO.md
@@ -174,13 +174,11 @@ Choose a strong password.
 
 In the camera's web interface, do the following (note that these instructions are for the aforementioned Amcrest camera):
 
-1) Go Setup -> Camera -> Video -> Main Stream. Set the Encode Mode to H.264, Smart Codec to Off, resolution to 1280x720(720P), framerate to 10, Bit Rate Type to CBR, and Bit Rate to Customized. Then uncheck Watermark Settings, and disable Sub stream. Make sure to press Save. These suggestions (and the ones below for audio) are simply based on my experience. With these, the videos have adequate quality and Privastead achieves good performance. You might need to change these based on your network connection's bandwidth.
+1) **Go Setup -> Camera -> Video -> Main Stream**. Set the Encode Mode to H.264, Smart Codec to Off, resolution to 1280x720(720P), framerate to 10, Bit Rate Type to CBR, and Bit Rate to Customized. Then uncheck Watermark Settings, and ensure Sub stream is enabled. We suggest using the following parameters for substream: Encode Mode: MJPEG, Resolution: VGA, frame rate: 10, bit rate: 1024. Make sure to press Save. These suggestions (and the ones below for audio) are simply based on my experience. With these, the videos have adequate quality and Privastead achieves good performance. You might need to change these based on your network connection's bandwidth.
 
-2) Then go to Setup -> Camera -> Audio. Under Main Stream, set Encode Mode to AAC and sampling frequency to 8000. Disable Sub Stream. Press Save.
+2) **Go to Setup -> Camera -> Audio**. Under Main Stream, set Encode Mode to AAC and sampling frequency to 8000. Disable Sub Stream. Press Save.
 
-3) Go Setup -> Camera -> Video -> Overlay. Disable Channel Title, Time, and Logo Overlay to remove clutter from the video.
-
-4) Go to Setup -> System -> General -> Date&Time. Set the date (including the correct timezone) and press on PC Sync. The latter syncs the time on the camera to that of the local machine.This step is needed since without it, the Privastead hub cannot authenticate to the IP camera through the ONVIF interface. (Quite annoyingly) you'll have to redo this last step (the PC Sync) whenever you reset the camera (e.g., unplug/plug).
+3) **Go Setup -> Camera -> Video -> Overlay**. Disable Channel Title, Time, and Logo Overlay to remove clutter from the video, and reduce any effects this might have on built-in motion detection.
 
 You are now done configuring the camera. Make sure to connect the machine to the Internet using WiFi.
 
@@ -196,6 +194,7 @@ You can add as many cameras as you want by copy and pasting the individual camer
   - name: "Front Door"
     ip: "IP address of camera configured in Step 3"
     rtsp_port: 554
+    motion_fps: 5
     username: "username here"
     password: "password here"
 ```
@@ -203,6 +202,8 @@ You can add as many cameras as you want by copy and pasting the individual camer
 You may choose to omit the username and password, which will instead prompt you upon executing the program below.
 
 The RTSP port is usually 554, but may vary depending on your camera.
+
+Motion FPS is the amount of times per second that we run our motion detection algorithm against the most recent frame.
 
 ```
 mv /address/to/user_credentials /path-to-privastead/camera_hub

--- a/README.md
+++ b/README.md
@@ -43,14 +43,13 @@ They mean that if the key used to encrypt a video between the hub and the app is
 ## Supported Cameras
 
 Privastead camera can theoretically support any IP camera (or any other camera that has an open interface).
-The current prototype relies on RTSP and ONVIF support by the camera.
-The former is used for streaming videos from the camera and the latter is used for querying events.
+The current prototype relies on RTSP and MJPEG support by the camera.
+The former is used for streaming videos from the camera and the latter is used for a custom motion detection implementation.
 So far, the following cameras have been tested:
 
 * Amcrest, model: IP4M-1041W ([Link](https://www.amazon.com/Amcrest-UltraHD-Security-4-Megapixel-IP4M-1041W/dp/B095XD17K5/) on Amazon)
     * Software Version: V2.800.00AC006.0.R, Build Date: 2023-10-27
     * WEB Version: V3.2.1.18144
-    * ONVIF Version: 21.12(V3.1.0.1207744)
 
 ## Supported mobile OSes
 
@@ -73,6 +72,7 @@ So far, the following cameras have been tested:
 
 ## (Current) key limitations
 
+* The camera hub relies on MJPEG instead of H.264 frames for custom motion detection
 * The camera hub pairs with one app instance only.
 * Performance may become a bottleneck for high camera resolutions and frame rates.
 

--- a/camera_hub/Cargo.toml
+++ b/camera_hub/Cargo.toml
@@ -34,3 +34,7 @@ anyhow = "1.0.41"
 bytes = "1.0.1"
 futures = "0.3.14"
 serde_yml = "0.0.12"
+ndarray = "0.15" # This has to be 0.15 to support linfa
+linfa = "0.7.1"
+linfa-clustering = "0.7.1"
+http-auth = "0.1"

--- a/camera_hub/example_cameras.yaml
+++ b/camera_hub/example_cameras.yaml
@@ -5,13 +5,16 @@ server:
 # List cameras in form of name, IP, RTSP port and username/password.
 # Username and password do not need to be included here. They can be left blank / removed and then entered in at runtime.
 # 554 is the default RTSP port
+# Motion FPS is the amount of times per second that we run our motion detection algorithm against the most recent frame
 cameras:
   - name: "Camera One"
     ip: "192.168.1.2"
     rtsp_port: 554
+    motion_fps: 5
     username: "example"
     password: "example"
 
   - name: "Camera Two"
     ip: "192.168.1.3"
     rtsp_port: 554
+    motion_fps: 10

--- a/camera_hub/src/detect_motion.rs
+++ b/camera_hub/src/detect_motion.rs
@@ -1,0 +1,393 @@
+//! Code to implement custom motion detection for the IP camera(s)
+//! Assumes the cameras supports MJPEG
+//!
+//! Copyright (C) 2025  Ardalan Amiri Sani
+//!
+//! This program is free software: you can redistribute it and/or modify
+//! it under the terms of the GNU General Public License as published by
+//! the Free Software Foundation, either version 3 of the License, or
+//! (at your option) any later version.
+//!
+//! This program is distributed in the hope that it will be useful,
+//! but WITHOUT ANY WARRANTY; without even the implied warranty of
+//! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//! GNU General Public License for more details.
+//!
+//! You should have received a copy of the GNU General Public License
+//! along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::{io, thread};
+use std::io::{BufRead, BufReader, Read};
+use std::ops::Div;
+use std::process::exit;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+use image::{GenericImageView, GrayImage, imageops, ImageReader};
+use linfa::Dataset;
+use linfa::dataset::Labels;
+use linfa::prelude::Transformer;
+use linfa_clustering::AppxDbscan;
+use ndarray::{Array, Array2, Ix1, OwnedRepr};
+use reqwest::blocking::{Client, Response};
+use reqwest::header::{CONTENT_TYPE, HeaderValue};
+use crate::Camera;
+
+const ALPHA: f32 = 0.05; // Background update rate
+const THRESHOLD: u8 = 70; // Motion detection threshold
+
+const DBSCAN_TOLERANCE: f64 = 20.; // The minimum distance from a given point to a nearby point for it to be considered part of a cluster
+const MINIMUM_TOTAL_CLUSTERED_POINTS: usize = 700; // The minimum sum of the points within all the clustered groups to be considered motion
+const MINIMUM_INDIVIDUAL_CLUSTER_POINTS: usize = 400; // The minimum amount of points for a cluster to be considered not noise
+const MINIMUM_GLOBAL_POINTS: usize = 2500; // The minimum amount of individual global points (could be noise) to be considered motion
+
+pub struct MotionDetection {
+    latest_frame: Arc<Mutex<Option<MPEGFrame>>>,
+    motion: Option<BackgroundSubtractor>,
+    last_detection: Option<SystemTime>, // This is meant for checking the last frame we ran motion detection on against the current frame timestamp.
+    camera: Camera, // We store this for checking the motion FPS later on
+}
+
+pub(crate) struct MPEGFrame {
+    frame: Vec<u8>,
+    timestamp: SystemTime,
+}
+
+#[derive(Clone)]
+pub(crate) struct BackgroundSubtractor {
+    background: Array2<f32>,
+}
+
+impl BackgroundSubtractor {
+    /// Initialize with the first frame
+    pub(crate) fn new(initial_frame: &GrayImage) -> Self {
+        let (width, height) = initial_frame.dimensions();
+
+        // Directly convert the GrayImage buffer to a ndarray
+        let bg_vec: Vec<f32> = initial_frame
+            .as_raw()
+            .iter()
+            .map(|&p| p as f32)
+            .collect();
+
+        let bg = Array2::from_shape_vec((height as usize, width as usize), bg_vec)
+            .expect("Failed to create ndarray from initial frame");
+
+        BackgroundSubtractor { background: bg }
+    }
+
+    /// Update background model and detect motion
+    pub(crate) fn apply(&mut self, frame: &GrayImage) -> GrayImage {
+        let (width, height) = frame.dimensions();
+
+        // Convert GrayImage to ndarray efficiently
+        let frame_vec: Vec<f32> = frame.as_raw().iter().map(|&p| p as f32).collect();
+        let frame_array = Array2::from_shape_vec((height as usize, width as usize), frame_vec)
+            .expect("Failed to create ndarray from frame");
+
+        // Compute absolute difference
+        let diff = (&frame_array - &self.background).mapv(f32::abs);
+
+        // Update background model using an exponential moving average
+        self.background = (&frame_array * ALPHA) + (&self.background * (1.0 - ALPHA));
+
+        // Threshold the difference array to create the motion mask
+        let mask = diff.mapv(|v| if v > THRESHOLD as f32 { 255u8 } else { 0u8 });
+
+        // Convert ndarray to GrayImage using direct byte copy
+        let output_vec: Vec<u8> = mask.into_raw_vec();
+        GrayImage::from_raw(width, height, output_vec)
+            .expect("Failed to create GrayImage from ndarray")
+    }
+}
+
+impl MotionDetection {
+    pub fn new(camera: &Camera) -> io::Result<Self> {
+        let latest_frame: Arc<Mutex<Option<MPEGFrame>>> = Arc::new(Mutex::new(None));
+        let latest_frame_clone = Arc::clone(&latest_frame);
+        let camera_clone = camera.clone();
+
+        thread::spawn(move || {
+            debug!("Starting MJPEG motion detection background thread");
+            Self::process_mjpeg_stream(&latest_frame_clone, camera_clone);
+        });
+
+        Ok(Self {
+            latest_frame,
+            motion: None,
+            last_detection: None,
+            camera: camera.clone(),
+        })
+    }
+
+    /// Reads the multipart/x-mixed-replace stream, printing debug info for each line,
+    /// and attempts to parse `Content-Length` to read JPEG frames.
+    fn process_mjpeg_stream(latest_frame: &Arc<Mutex<Option<MPEGFrame>>>, camera: Camera) {
+        let url = format!("http://{}/cgi-bin/mjpg/video.cgi?subtype=1", camera.ip);
+        let url_req = reqwest::Url::try_from(url.as_str()).unwrap();
+
+        // We make an initial request to get the Digest Auth challenge
+        let client = Client::new();
+        let response = client.get(url_req.clone()).send().expect("");
+
+        if response.status() != 401 {
+            println!("Unexpected status from camera MJPEG attempt: {}", response.status());
+            exit(1);
+        }
+
+        // Extract Digest parameters from WWW-Authenticate header returned
+        let www_authenticate = response
+            .headers()
+            .get("www-authenticate")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        let mut pw_client = http_auth::PasswordClient::try_from(www_authenticate).expect("Unable to instantiate PasswordClient from www_authenticate for MJPEG stream");
+        let authorization = pw_client
+            .respond(&http_auth::PasswordParams {
+                username: camera.username.clone().as_str(),
+                password: camera.password.clone().as_str(),
+                uri: url_req.path(),
+                method: reqwest::Method::GET.as_str(),
+                body: Some(&[]),
+            })
+            .unwrap();
+        debug!("MJPG Authorization: {}", &authorization);
+        let mut authorization = HeaderValue::try_from(authorization).unwrap();
+        authorization.set_sensitive(true);
+
+        // Make the authenticated request with Digest Auth
+        let response = client
+            .get(url_req)
+            .header(reqwest::header::AUTHORIZATION, authorization)
+            .send().expect("");
+
+        if !response.status().is_success() {
+            println!("Failed to authenticate to camera MJPEG: HTTP {}", response.status());
+            exit(1);
+        }
+
+        // Detect boundary from Content-Type
+        let boundary = Self::get_mjpeg_boundary(&response)
+            .unwrap_or_else(|| "--myboundary".to_string()); // fallback is "myboundary", seems to be the default in Amcrest cameras
+        debug!("Using boundary: {}", boundary);
+
+        let mut reader = BufReader::new(response);
+        loop {
+            // Read lines until we see one that starts with --<boundary> or we reach EOF
+            let maybe_line = Self::read_ascii_line(&mut reader)
+                .expect("Error reading line from camera stream.");
+
+            if maybe_line.is_none() {
+                debug!("EOF reached... exiting MJPEG loop.");
+                break;
+            }
+
+            let line = maybe_line.unwrap();
+
+            let trimmed = line.trim();
+            if trimmed.starts_with(&boundary) {
+                // Found the start of a part
+                let mut content_length: Option<usize> = None;
+
+                // Now read headers until blank line
+                loop {
+                    let hdr_line = Self::read_ascii_line(&mut reader)
+                        .expect("Failed to read header line.");
+
+                    if hdr_line.is_none() {
+                        return;
+                    }
+
+                    let hdr_line = hdr_line.unwrap();
+                    let hdr_trimmed = hdr_line.trim();
+
+                    if hdr_trimmed.is_empty() {
+                        // blank line means next is the JPEG bytes
+                        break;
+                    }
+
+                    if let Some(cl) = hdr_trimmed.strip_prefix("Content-Length:") {
+                        let len_str = cl.trim();
+                        let len = len_str
+                            .parse::<usize>()
+                            .expect("Content-Length not a valid integer.");
+                        content_length = Some(len);
+                    }
+                }
+
+                // If we got a content length, then we can read exactly that many bytes for JPEG
+                if let Some(len) = content_length {
+                    let mut frame_data = vec![0u8; len];
+                    reader
+                        .read_exact(&mut frame_data)
+                        .expect("Failed reading JPEG data from stream.");
+
+                    // Acquire the mutex and replace the latest frame.
+                    let mut binding = latest_frame.lock().unwrap();
+                    *binding = Some(MPEGFrame {
+                        frame: frame_data,
+                        timestamp: SystemTime::now(),
+                    });
+                } else {
+                    debug!("No Content-Length header found for this part");
+                }
+            }
+        }
+    }
+
+    /// Attempts to extract boundary from Content-Type: multipart/x-mixed-replace; boundary=...
+    fn get_mjpeg_boundary(resp: &Response) -> Option<String> {
+        if let Some(ct_val) = resp.headers().get(CONTENT_TYPE) {
+            let ct_str = ct_val.to_str().ok()?;
+            if let Some(idx) = ct_str.to_lowercase().find("boundary=") {
+                let after = &ct_str[idx + "boundary=".len()..];
+                // Trim semicolons/spaces/quotes
+                let boundary_str = after.trim_matches(|c: char| {
+                    c.is_whitespace() || c == ';' || c == '"'
+                });
+                if !boundary_str.is_empty() {
+                    // Ensure the boundary lines in the stream are prefixed with "--",
+                    if !boundary_str.starts_with("--") {
+                        return Some(format!("--{}", boundary_str));
+                    }
+                    return Some(boundary_str.to_string());
+                }
+            }
+        }
+        None
+    }
+
+    /// Reads a line (ends with b'\n'), returns None if EOF without data.
+    fn read_ascii_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<String>> {
+        let mut buffer = Vec::new();
+        let bytes_read = reader
+            .read_until(b'\n', &mut buffer)
+            .expect("read_until failed.");
+
+        if bytes_read == 0 {
+            // We reached EOF
+            return Ok(None);
+        }
+
+        // Strip trailing newline and/or carriage return
+        while buffer.ends_with(&[b'\n']) || buffer.ends_with(&[b'\r']) {
+            buffer.pop();
+        }
+
+        // Convert to String (lossy), so invalid UTF-8 won't cause errors
+        let line_str = String::from_utf8_lossy(&buffer).to_string();
+        Ok(Some(line_str))
+    }
+
+    pub fn handle_motion_event(&mut self) -> io::Result<bool> {
+        let binding = self.latest_frame.lock().unwrap();
+        if let Some(latest_frame) = binding.as_ref() {
+            let latest_video_time = latest_frame.timestamp;
+            let latest_video = latest_frame.frame.clone();
+
+            // Ensure that either no detection has occurred before, or that this isn't the same frame as last time.
+            if self.last_detection.is_none() ||
+                self.last_detection.map(|last_time| latest_video_time.duration_since(last_time).map(|d| d >= Duration::from_millis(1000.div(self.camera.motion_fps))).unwrap_or(false)).unwrap_or(false) {
+                let decoded = ImageReader::new(io::Cursor::new(latest_video))
+                    .with_guessed_format()
+                    .expect("Could not guess JPEG format")
+                    .decode()
+                    .expect("Failed to decode JPEG frame");
+
+                // Update our last checked frame to the current one.
+                self.last_detection = Some(latest_video_time);
+
+                // Convert to grayscale for better comparison
+                let mut grayscale = decoded.to_luma8();
+
+                let (mut width, mut height) = decoded.dimensions();
+                if width > 640 && height > 480 {
+                    // Enforce 640x480 as the maximum. This is to reduce system strain on CPU usage, as the higher it is, it will grow exponentially from here.
+                    // 320x240 was tested, but unfortunately I don't think the massive loss in accuracy is worth the performance boost
+                    // TODO: We may need to re-think this approach for outdoor cameras.
+                    width = 640;
+                    height = 480;
+                    grayscale = imageops::resize(&grayscale, 640, 480, imageops::FilterType::Nearest);
+                }
+
+                // Determine how much we need to scale our constants for minimum point motion detection based on the tested resolution (640x480)
+                let points_scale_factor: f64 = (width as f64 * height as f64) / (640.0 * 480.0);
+
+                if self.motion.is_none() {
+                    // We instantiate the BackgroundSubtractor with our first image as a baseline to compare to.
+                    self.motion = Some(BackgroundSubtractor::new(&grayscale));
+                } else {
+                    let diff_result = self.motion.clone().unwrap().apply(&grayscale);
+                    let mut data_vec = Vec::new();
+                    let mut targets = Vec::new();
+
+                    // Iterate efficiently without unnecessary variable tracking
+                    for (x, y, pixel) in diff_result.enumerate_pixels() {
+                        if pixel[0] == 255 {
+                            data_vec.extend_from_slice(&[x as f64, y as f64]);
+                            targets.push(1.0);
+                        }
+                    }
+
+                    let total_amt_of_points = targets.len();
+
+                    // We don't need to perform DBScan if we have a massive amount of differing points (as noise isn't possible in this quantity)
+                    if total_amt_of_points as f64 >= points_scale_factor * MINIMUM_GLOBAL_POINTS as f64 {
+                        self.motion = Some(BackgroundSubtractor::new(&grayscale));
+                        debug!("Motion was detected via global analysis with {} total points", total_amt_of_points);
+
+                        // Should you wish to see the computed motion difference images, uncomment this block (and the other below)
+                        /*
+                        let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+                        let millis = current_time.as_secs() * 1000 + current_time.subsec_nanos() as u64 / 1_000_000;
+                        diff_result.save(format!("difference_global_{:?}.png", millis)).expect("Failed to save difference image!");
+                        */
+
+                        return Ok(true);
+                    } else if total_amt_of_points as f64 >= points_scale_factor * MINIMUM_TOTAL_CLUSTERED_POINTS as f64 {  // We don't need to check the clusters if the global amount of points don't exceed the min clustered amount
+                        // Else, if there's less, we may still want to observe to see if there's large *localized* cluster(s) of points that moved
+
+                        // We formulate a dataset with these changed points
+                        let x: ndarray::ArrayBase<OwnedRepr<f64>, ndarray::Ix2> =
+                            Array::from_shape_vec((total_amt_of_points, 2), data_vec).expect("Was not able to convert to X");
+                        let y: ndarray::ArrayBase<OwnedRepr<f64>, ndarray::Ix1> = Array::from_shape_vec(total_amt_of_points, targets).expect("Was not able to convert to Y");
+                        let dataset: Dataset<f64, f64, Ix1> = Dataset::new(x, y);
+
+                        // Thus, we compute an approximation of DBScan (the approximation itself seems to not be implemented in linfa yet, but will future-proof our impl),
+                        // which can find clusters of *grouped* differing points to determine if we have noise or something that actually moved.
+                        let cluster_memberships = AppxDbscan::params((points_scale_factor * MINIMUM_INDIVIDUAL_CLUSTER_POINTS as f64) as usize).tolerance(points_scale_factor * DBSCAN_TOLERANCE).transform(dataset).unwrap();
+                        let label_count = cluster_memberships.label_count().remove(0);
+
+                        let mut total_count = 0;
+                        for (label, count) in label_count {
+                            if label.is_some() {
+                                // We've detected a cluster of grouped points, so we accumulate it
+                                total_count += count;
+                            }
+                        }
+
+                        if total_count as f64 >= points_scale_factor * MINIMUM_TOTAL_CLUSTERED_POINTS as f64 {
+                            // We replace the BackgroundSubtractor with the current image. This helps account for a major change in the image such as a new object being placed, etc.
+                            // Should there be no huge change, and the image reverts back to the baseline, it'll just be replaced again shortly after at this same point without ill effect.
+                            // This is due to us capping the motion detection notification rate at a minimum of 60 seconds.
+                            self.motion = Some(BackgroundSubtractor::new(&grayscale));
+                            debug!("Motion was detected via cluster analysis with {} clustered points and {} total points", total_count, total_amt_of_points);
+
+                            // Should you wish to see the computed motion difference images, uncomment this block (and the other above)
+                            /*
+                            let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+                            let millis = current_time.as_secs() * 1000 + current_time.subsec_nanos() as u64 / 1_000_000;
+                            diff_result.save(format!("difference_cluster_{:?}.png", millis)).expect("Failed to save difference image!");
+                            */
+
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+
+
+        return Ok(false);
+    }
+}

--- a/server/src/tcpserver_mio.rs
+++ b/server/src/tcpserver_mio.rs
@@ -136,7 +136,7 @@ impl TcpServer {
                             }
                         }
                         Err(e) => {
-                            panic!("Could not read file from directory: {:?}", e);
+                            panic!("This may have to do with you not putting your user_credentials file within a folder called user_credentials (the file can be renamed to anything). Could not read file from directory: {:?}", e);
                         }
                     }
                 }


### PR DESCRIPTION
This pull request refactors the Privastead Camera Hub to get rid of dependence on ONVIF-based motion detection events. Instead, we use the MJPEG stream provided by Amcrest cameras (and also lots of other IP cameras) to get direct access to the video frames, and implement a custom motion detection algorithm using Background Subtraction and DBScan clustering. This will allow for future usage of object detection within the images now that we have direct access to the image frames from the hub.

The reason for not using H.264 decoding directly is due to the lack of a **native** H.264 decoder in Rust currently. This will be replaced in the future to add support for more IP cameras and get rid of the extra stream.

Key Changes:
- Removing all ONVIF related code
- Implementing a custom MJPEG streamer to fetch regular image frames, for use in motion analysis
- Creation of a BackgroundSubtraction module, which is replaced every time motion occurs to account for potential environmental changes (such as the placement of a new plant in the room, new lighting..). This isn't an issue due to us only sending a motion notification at a minimum of once per minute, so it will be normalized before the minute is up and won't trigger two motion notifications. The BackgroundSubtraction also modifies itself by weighting past frames and new frames together when checking for differences to account for things such as gradual light changes throughout the day.
- Motion detection via analysis of differing pixels from the BackgroundSubtraction module. First, we look globally at all pixels that were changed. If this exceeds a certain threshold (which is based off of the camera resolution), then it is considered motion. Should this not be exceeded, DBScan is used to find certain clustered groups within the image (as highly concentrated clusters of changed pixels indicate movement and greatly reduce the probability of basing our prediction off of noise). The amount within each clustered group are accumulated together and checked against a different **smaller** threshold (again, based on the camera resolution) to check for motion there as well.
- Camera-based credentials are now checked through the RTSP stream with a verbose error message.
- A 'motion_fps' setting was introduced in the cameras.yaml file to allow for potential reduction to get better performance.
- A bug was fixed in the primary camera loop that was not correctly enforcing a 60s delay between motion videos.