### PR TITLE
Harden staged install paths in update and deploy

### DIFF
--- a/deploy/src-tauri/assets/server/provision_server.sh
+++ b/deploy/src-tauri/assets/server/provision_server.sh
@@ -29,6 +29,7 @@ STATE_DIR="${STATE_DIR:-/var/lib/secluso}"
 SERVICE_USER="${SERVICE_USER:-secluso}"
 RELEASE_TAG="${RELEASE_TAG:-unknown}"
 UPDATE_INTERVAL_SECS="${UPDATE_INTERVAL_SECS:-1800}"
+STAGING_DIR="${STAGING_DIR:-}"
 SIG_ARGS=""
 if [[ -n "${SIG_KEYS:-}" ]]; then
   IFS=',' read -r -a sig_list <<< "$SIG_KEYS"
@@ -51,6 +52,19 @@ emit "info" "config" "BIND_ADDRESS=${BIND_ADDRESS:-127.0.0.1}"
 emit "info" "config" "LISTEN_PORT=${LISTEN_PORT:-8000}"
 emit "info" "config" "RELEASE_TAG=$RELEASE_TAG"
 emit "info" "config" "GITHUB_TOKEN=${GITHUB_TOKEN:+set}"
+emit "info" "config" "STAGING_DIR=${STAGING_DIR:+set}"
+
+# Everything this installer trusts now comes from one per-run staging dir.
+if [[ -z "$STAGING_DIR" || ! -d "$STAGING_DIR" ]]; then
+  emit "error" "install" "Missing uploaded staging directory"
+  exit 1
+fi
+
+SERVER_STAGE="$STAGING_DIR/secluso-server"
+UPDATER_STAGE="$STAGING_DIR/secluso-update"
+SERVICE_ACCOUNT_STAGE="$STAGING_DIR/service_account_key.json"
+USER_CREDENTIALS_STAGE="$STAGING_DIR/user_credentials"
+CREDENTIALS_FULL_STAGE="$STAGING_DIR/credentials_full"
 
 if [[ "${OVERWRITE:-0}" == "1" ]]; then
   emit "warn" "overwrite" "Overwrite enabled: stopping services and deleting Secluso install directories"
@@ -73,33 +87,31 @@ fi
 emit "info" "install" "Ensuring install and state directories..."
 ${SUDO} mkdir -p "$INSTALL_PREFIX/bin" "$INSTALL_PREFIX/current_version" "$STATE_DIR" "$STATE_DIR/user_credentials"
 
-if [[ ! -x /tmp/secluso-server ]]; then
-  emit "error" "install" "Missing uploaded /tmp/secluso-server binary"
+if [[ ! -f "$SERVER_STAGE" ]]; then
+  emit "error" "install" "Missing staged server binary"
   exit 1
 fi
-if [[ ! -x /tmp/secluso-update ]]; then
-  emit "error" "install" "Missing uploaded /tmp/secluso-update binary"
+if [[ ! -f "$UPDATER_STAGE" ]]; then
+  emit "error" "install" "Missing staged updater binary"
   exit 1
 fi
 
 emit "info" "install" "Installing verified binaries..."
-${SUDO} install -m 0755 /tmp/secluso-server "$INSTALL_PREFIX/bin/secluso-server"
-${SUDO} install -m 0755 /tmp/secluso-update "$INSTALL_PREFIX/bin/secluso-update"
-${SUDO} rm -f /tmp/secluso-server /tmp/secluso-update
+# The uploaded files only become live binaries here.
+${SUDO} install -m 0755 "$SERVER_STAGE" "$INSTALL_PREFIX/bin/secluso-server"
+${SUDO} install -m 0755 "$UPDATER_STAGE" "$INSTALL_PREFIX/bin/secluso-update"
 printf '%s\n' "${RELEASE_TAG#v}" | ${SUDO} tee "$INSTALL_PREFIX/current_version/server" >/dev/null
 printf '%s\n' "${RELEASE_TAG#v}" | ${SUDO} tee "$INSTALL_PREFIX/current_version/updater" >/dev/null
 
-if [[ -f /tmp/service_account_key.json ]]; then
+if [[ -f "$SERVICE_ACCOUNT_STAGE" ]]; then
   emit "info" "secrets" "Installing service account key"
-  ${SUDO} install -m 0600 /tmp/service_account_key.json "$STATE_DIR/service_account_key.json"
-  ${SUDO} rm -f /tmp/service_account_key.json
+  ${SUDO} install -m 0600 "$SERVICE_ACCOUNT_STAGE" "$STATE_DIR/service_account_key.json"
 fi
 
 if [[ "${FIRST_INSTALL:-0}" == "1" ]]; then
   emit "info" "secrets" "Installing freshly generated user credentials"
-  ${SUDO} install -m 0600 /tmp/user_credentials "$STATE_DIR/user_credentials/user_credentials"
-  ${SUDO} install -m 0600 /tmp/credentials_full "$STATE_DIR/credentials_full"
-  ${SUDO} rm -f /tmp/user_credentials /tmp/credentials_full
+  ${SUDO} install -m 0600 "$USER_CREDENTIALS_STAGE" "$STATE_DIR/user_credentials/user_credentials"
+  ${SUDO} install -m 0600 "$CREDENTIALS_FULL_STAGE" "$STATE_DIR/credentials_full"
 fi
 
 ${SUDO} chown -R "$SERVICE_USER:$SERVICE_USER" "$STATE_DIR"
@@ -162,5 +174,8 @@ else
   ${SUDO} systemctl disable --now "$UPDATER_SERVICE" 2>/dev/null || true
   emit "warn" "systemd" "updater disabled"
 fi
+
+# No reason to leave the staged payloads around once install is done.
+rm -rf "$STAGING_DIR" 2>/dev/null || ${SUDO} rm -rf "$STAGING_DIR" 2>/dev/null || true
 
 emit "info" "done" "DONE"

--- a/deploy/src-tauri/src/provision_server/provision.rs
+++ b/deploy/src-tauri/src/provision_server/provision.rs
@@ -4,7 +4,9 @@ use crate::pi_hub_provision::temp::shared_temp_dir;
 use crate::provision_server::events::{log_line, step_ok, step_start};
 use crate::provision_server::preflight::run_preflight;
 use crate::provision_server::script::remote_provision_script;
-use crate::provision_server::ssh::{connect_ssh, exec_remote_script_streaming, scp_upload_bytes, sudo_prefix};
+use crate::provision_server::ssh::{
+  cleanup_remote_path, connect_ssh, create_remote_temp_dir, exec_remote_script_streaming, scp_upload_bytes, sudo_prefix,
+};
 use crate::provision_server::types::{ServerPlan, ServerSecrets, SshTarget};
 use anyhow::{bail, Context, Result};
 use reqwest::blocking::Client;
@@ -30,6 +32,10 @@ struct DownloadedArtifacts {
   server_manifest_version: String,
   server_bytes: Vec<u8>,
   updater_bytes: Vec<u8>,
+}
+
+fn remote_stage_path(stage_dir: &str, name: &str) -> String {
+  format!("{stage_dir}/{name}")
 }
 
 fn normalize_repo(input: &str) -> String {
@@ -187,144 +193,188 @@ pub fn run_provision(app: &AppHandle, run_id: Uuid, target: SshTarget, plan: Ser
   }
 
   let mut generated_user_credentials: Option<Vec<u8>> = None;
+  // Give each provisioning run its own remote staging dir.
+  // Installer now reads inputs from one private per-run location instead of fixed top-level temp paths.
+  let remote_stage_dir = create_remote_temp_dir(&sess, "secluso-provision")
+    .context("creating remote staging dir")?;
 
-  step_start(app, run_id, "artifacts", "Downloading verified release binaries");
-  let artifacts = download_verified_artifacts(
-    app,
-    run_id,
-    &owner_repo,
-    &preflight.remote_arch,
-    &sig_keys,
-    plan.github_token.as_deref(),
-  )?;
-  scp_upload_bytes(&sess, "/tmp/secluso-server", 0o755, &artifacts.server_bytes)?;
-  scp_upload_bytes(&sess, "/tmp/secluso-update", 0o755, &artifacts.updater_bytes)?;
-  step_ok(app, run_id, "artifacts");
-
-  // step 2 generate and upload secrets
-  step_start(app, run_id, "secrets", "Preparing runtime secrets");
-  let secrets = plan.secrets.as_ref().context("Missing secrets config")?;
-  let sa_path = PathBuf::from(&secrets.service_account_key_path);
-  let sa = std::fs::read(&sa_path).with_context(|| format!("Missing service account key at {}", sa_path.display()))?;
-  scp_upload_bytes(&sess, "/tmp/service_account_key.json", 0o600, &sa)?;
-
-  if first_install {
-    let work_dir = shared_temp_dir("secluso-server-creds").context("creating temp work dir")?;
-    let work_path = work_dir.path();
-    let sig_keys = plan.sig_keys.as_ref().map(|keys| {
-      keys
-        .iter()
-        .map(|k| crate::pi_hub_provision::model::SigKey {
-          name: k.name.trim().to_string(),
-          github_user: k.github_user.trim().to_string(),
-        })
-        .collect::<Vec<_>>()
-    });
-    generate_user_credentials_only(
+  let provision_result = (|| -> Result<()> {
+    step_start(app, run_id, "artifacts", "Downloading verified release binaries");
+    let artifacts = download_verified_artifacts(
       app,
       run_id,
-      work_path,
-      &secrets.server_url,
       &owner_repo,
-      sig_keys.as_deref(),
+      &preflight.remote_arch,
+      &sig_keys,
       plan.github_token.as_deref(),
     )?;
+    // Keep the uploaded binaries non-executable here.
+    // They only become executable when the remote installer places them into the actual install path.
+    scp_upload_bytes(
+      &sess,
+      &remote_stage_path(&remote_stage_dir, "secluso-server"),
+      0o600,
+      &artifacts.server_bytes,
+    )?;
+    scp_upload_bytes(
+      &sess,
+      &remote_stage_path(&remote_stage_dir, "secluso-update"),
+      0o600,
+      &artifacts.updater_bytes,
+    )?;
+    step_ok(app, run_id, "artifacts");
 
-    let uc_path = work_path.join("user_credentials");
-    let uc = std::fs::read(&uc_path).with_context(|| format!("Missing user credentials at {}", uc_path.display()))?;
-    let credentials_full_path = work_path.join("credentials_full");
-    let credentials_full = std::fs::read(&credentials_full_path)
-      .with_context(|| format!("Missing credentials_full at {}", credentials_full_path.display()))?;
+    // step 2 generate and upload secrets
+    step_start(app, run_id, "secrets", "Preparing runtime secrets");
+    let secrets = plan.secrets.as_ref().context("Missing secrets config")?;
+    let sa_path = PathBuf::from(&secrets.service_account_key_path);
+    let sa = std::fs::read(&sa_path).with_context(|| format!("Missing service account key at {}", sa_path.display()))?;
+    scp_upload_bytes(
+      &sess,
+      &remote_stage_path(&remote_stage_dir, "service_account_key.json"),
+      0o600,
+      &sa,
+    )?;
 
-    let qr_src = work_path.join("user_credentials_qrcode.png");
-    if !qr_src.exists() {
-      bail!("Missing QR code at {}", qr_src.display());
-    }
-    let qr_path = PathBuf::from(&secrets.user_credentials_qr_path);
-    if let Some(parent) = qr_path.parent() {
-      if !parent.as_os_str().is_empty() {
-        std::fs::create_dir_all(parent)?;
+    if first_install {
+      let work_dir = shared_temp_dir("secluso-server-creds").context("creating temp work dir")?;
+      let work_path = work_dir.path();
+      let sig_keys = plan.sig_keys.as_ref().map(|keys| {
+        keys
+          .iter()
+          .map(|k| crate::pi_hub_provision::model::SigKey {
+            name: k.name.trim().to_string(),
+            github_user: k.github_user.trim().to_string(),
+          })
+          .collect::<Vec<_>>()
+      });
+      generate_user_credentials_only(
+        app,
+        run_id,
+        work_path,
+        &secrets.server_url,
+        &owner_repo,
+        sig_keys.as_deref(),
+        plan.github_token.as_deref(),
+      )?;
+
+      let uc_path = work_path.join("user_credentials");
+      let uc = std::fs::read(&uc_path).with_context(|| format!("Missing user credentials at {}", uc_path.display()))?;
+      let credentials_full_path = work_path.join("credentials_full");
+      let credentials_full = std::fs::read(&credentials_full_path)
+        .with_context(|| format!("Missing credentials_full at {}", credentials_full_path.display()))?;
+
+      let qr_src = work_path.join("user_credentials_qrcode.png");
+      if !qr_src.exists() {
+        bail!("Missing QR code at {}", qr_src.display());
       }
-    }
-    std::fs::copy(&qr_src, &qr_path).with_context(|| format!("Saving QR code to {}", qr_path.display()))?;
+      let qr_path = PathBuf::from(&secrets.user_credentials_qr_path);
+      if let Some(parent) = qr_path.parent() {
+        if !parent.as_os_str().is_empty() {
+          std::fs::create_dir_all(parent)?;
+        }
+      }
+      std::fs::copy(&qr_src, &qr_path).with_context(|| format!("Saving QR code to {}", qr_path.display()))?;
 
-    scp_upload_bytes(&sess, "/tmp/user_credentials", 0o600, &uc)?;
-    scp_upload_bytes(&sess, "/tmp/credentials_full", 0o600, &credentials_full)?;
-    generated_user_credentials = Some(uc);
-  } else {
-    log_line(
-      app,
-      run_id,
-      "info",
-      Some("secrets"),
-      "Existing install detected. Leaving the current server credentials unchanged.".to_string(),
-    );
-  }
-  step_ok(app, run_id, "secrets");
-
-  // step 3 run the remote provision script
-  step_start(app, run_id, "remote", "Running remote installer");
-  let mut envs = vec![
-    ("INSTALL_PREFIX", INSTALL_PREFIX.to_string()),
-    ("OWNER_REPO", owner_repo.to_string()),
-    ("SERVER_UNIT", SERVER_UNIT.to_string()),
-    ("UPDATER_SERVICE", UPDATER_SERVICE.to_string()),
-    ("UPDATE_INTERVAL_SECS", UPDATE_INTERVAL_SECS.to_string()),
-    ("BIND_ADDRESS", plan.runtime.bind_address.clone()),
-    ("LISTEN_PORT", plan.runtime.listen_port.to_string()),
-    ("SUDO_CMD", sudo_cmd.clone()),
-    ("ENABLE_UPDATER", if plan.auto_updater.enable { "1".to_string() } else { "0".to_string() }),
-    ("OVERWRITE", if overwrite { "1".to_string() } else { "0".to_string() }),
-    ("FIRST_INSTALL", if first_install { "1".to_string() } else { "0".to_string() }),
-    ("RELEASE_TAG", artifacts.release_tag.clone()),
-    (
-      "SIG_KEYS",
-      sig_keys
-        .iter()
-        .map(|k| format!("{}:{}", k.name.trim(), k.github_user.trim()))
-        .filter(|v| !v.trim().is_empty())
-        .collect::<Vec<_>>()
-        .join(","),
-    ),
-  ];
-  if let Some(token) = plan.github_token.as_ref().map(|v| v.trim().to_string()).filter(|v| !v.is_empty()) {
-    envs.push(("GITHUB_TOKEN", token));
-  }
-  exec_remote_script_streaming(
-    app,
-    run_id,
-    "remote",
-    &sess,
-    &envs.iter().map(|(k, v)| (*k, v.clone())).collect::<Vec<_>>(),
-    sudo_pw,
-    remote_provision_script(),
-  )?;
-
-  step_ok(app, run_id, "remote");
-
-  step_start(app, run_id, "health", "Checking public server health");
-  if first_install {
-    if let Some(uc) = generated_user_credentials.as_ref() {
-      let probe_version = plan
-        .manifest_version_override
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(&artifacts.server_manifest_version);
-      verify_public_server_health(app, run_id, &plan, secrets, probe_version, uc)?;
+      scp_upload_bytes(
+        &sess,
+        &remote_stage_path(&remote_stage_dir, "user_credentials"),
+        0o600,
+        &uc,
+      )?;
+      scp_upload_bytes(
+        &sess,
+        &remote_stage_path(&remote_stage_dir, "credentials_full"),
+        0o600,
+        &credentials_full,
+      )?;
+      generated_user_credentials = Some(uc);
     } else {
-      log_line(app, run_id, "warn", Some("health"), "Skipping public health check because generated credentials are unavailable.".to_string());
+      log_line(
+        app,
+        run_id,
+        "info",
+        Some("secrets"),
+        "Existing install detected. Leaving the current server credentials unchanged.".to_string(),
+      );
     }
-  } else {
-    log_line(
+    step_ok(app, run_id, "secrets");
+
+    // step 3 run the remote provision script
+    step_start(app, run_id, "remote", "Running remote installer");
+    let mut envs = vec![
+      ("INSTALL_PREFIX", INSTALL_PREFIX.to_string()),
+      ("OWNER_REPO", owner_repo.to_string()),
+      ("SERVER_UNIT", SERVER_UNIT.to_string()),
+      ("UPDATER_SERVICE", UPDATER_SERVICE.to_string()),
+      ("UPDATE_INTERVAL_SECS", UPDATE_INTERVAL_SECS.to_string()),
+      ("BIND_ADDRESS", plan.runtime.bind_address.clone()),
+      ("LISTEN_PORT", plan.runtime.listen_port.to_string()),
+      ("SUDO_CMD", sudo_cmd.clone()),
+      ("ENABLE_UPDATER", if plan.auto_updater.enable { "1".to_string() } else { "0".to_string() }),
+      ("OVERWRITE", if overwrite { "1".to_string() } else { "0".to_string() }),
+      ("FIRST_INSTALL", if first_install { "1".to_string() } else { "0".to_string() }),
+      ("RELEASE_TAG", artifacts.release_tag.clone()),
+      // The remote script only trusts staged inputs under this directory for this run.
+      ("STAGING_DIR", remote_stage_dir.clone()),
+      (
+        "SIG_KEYS",
+        sig_keys
+          .iter()
+          .map(|k| format!("{}:{}", k.name.trim(), k.github_user.trim()))
+          .filter(|v| !v.trim().is_empty())
+          .collect::<Vec<_>>()
+          .join(","),
+      ),
+    ];
+    if let Some(token) = plan.github_token.as_ref().map(|v| v.trim().to_string()).filter(|v| !v.is_empty()) {
+      envs.push(("GITHUB_TOKEN", token));
+    }
+    exec_remote_script_streaming(
       app,
       run_id,
-      "info",
-      Some("health"),
-      "Skipping public health check for update-only runs because no new credentials were generated.".to_string(),
-    );
+      "remote",
+      &sess,
+      &envs.iter().map(|(k, v)| (*k, v.clone())).collect::<Vec<_>>(),
+      sudo_pw,
+      remote_provision_script(),
+    )?;
+
+    step_ok(app, run_id, "remote");
+
+    step_start(app, run_id, "health", "Checking public server health");
+    if first_install {
+      if let Some(uc) = generated_user_credentials.as_ref() {
+        let probe_version = plan
+          .manifest_version_override
+          .as_deref()
+          .map(str::trim)
+          .filter(|value| !value.is_empty())
+          .unwrap_or(&artifacts.server_manifest_version);
+        verify_public_server_health(app, run_id, &plan, secrets, probe_version, uc)?;
+      } else {
+        log_line(app, run_id, "warn", Some("health"), "Skipping public health check because generated credentials are unavailable.".to_string());
+      }
+    } else {
+      log_line(
+        app,
+        run_id,
+        "info",
+        Some("health"),
+        "Skipping public health check for update-only runs because no new credentials were generated.".to_string(),
+      );
+    }
+    step_ok(app, run_id, "health");
+    Ok(())
+  })();
+
+  // Old staged binaries and secrets do not need to hang around after the run finishes.
+  let cleanup_result = cleanup_remote_path(&sess, &remote_stage_dir);
+  if let Err(err) = provision_result {
+    let _ = cleanup_result;
+    return Err(err);
   }
-  step_ok(app, run_id, "health");
+  cleanup_result?;
   Ok(())
 }
 

--- a/deploy/src-tauri/src/provision_server/ssh.rs
+++ b/deploy/src-tauri/src/provision_server/ssh.rs
@@ -14,6 +14,12 @@ use uuid::Uuid;
 const SSH_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const SSH_IO_TIMEOUT: Duration = Duration::from_secs(30);
 
+struct RemoteExecResult {
+  stdout: String,
+  stderr: String,
+  exit: i32,
+}
+
 pub struct TempKeyFiles {
   pub key_file: Option<NamedTempFile>,
 }
@@ -278,4 +284,84 @@ pub fn scp_upload_bytes(sess: &Session, remote_path: &str, mode: i32, bytes: &[u
   remote.close().ok();
   remote.wait_close().ok();
   Ok(())
+}
+
+pub fn create_remote_temp_dir(sess: &Session, prefix: &str) -> Result<String> {
+  // Each run gets its own remote staging dir.
+  // Useful bit is that uploads for this run no longer collide with shared fixed temp paths.
+  let template = format!("/tmp/{prefix}.XXXXXX");
+  let cmd = format!(
+    "stage_dir=\"$(mktemp -d {})\" && chmod 700 \"$stage_dir\" && printf '%s' \"$stage_dir\"",
+    shell_escape(&template)
+  );
+  let result = remote_shell(sess, &cmd, None)?;
+  if result.exit != 0 {
+    bail!(
+      "Failed to create remote staging dir: {}",
+      summarize_remote_failure(&result)
+    );
+  }
+
+  let stage_dir = result.stdout.trim();
+  if stage_dir.is_empty() {
+    bail!("Failed to create remote staging dir: empty result");
+  }
+
+  Ok(stage_dir.to_string())
+}
+
+pub fn cleanup_remote_path(sess: &Session, remote_path: &str) -> Result<()> {
+  // Best to clear staged inputs once the provisioning run is over.
+  let cmd = format!("rm -rf -- {}", shell_escape(remote_path));
+  let result = remote_shell(sess, &cmd, None)?;
+  if result.exit != 0 {
+    bail!(
+      "Failed to clean up remote path {}: {}",
+      remote_path,
+      summarize_remote_failure(&result)
+    );
+  }
+  Ok(())
+}
+
+fn remote_shell(sess: &Session, cmd: &str, stdin: Option<&str>) -> Result<RemoteExecResult> {
+  let full = format!("bash -lc '{}'", shell_escape(cmd));
+  let mut channel = sess.channel_session().context("Failed to open SSH channel")?;
+  channel.exec(&full).with_context(|| format!("Remote exec failed: {cmd}"))?;
+  if let Some(stdin) = stdin {
+    channel.write_all(stdin.as_bytes()).ok();
+    channel.flush().ok();
+  }
+  channel.send_eof().ok();
+
+  let mut stdout = String::new();
+  let mut stderr = String::new();
+  channel.read_to_string(&mut stdout).ok();
+  channel.stderr().read_to_string(&mut stderr).ok();
+  channel.wait_close().ok();
+  let exit = channel.exit_status().unwrap_or(255);
+
+  Ok(RemoteExecResult { stdout, stderr, exit })
+}
+
+fn summarize_remote_failure(result: &RemoteExecResult) -> String {
+  let stderr = result.stderr.trim();
+  if !stderr.is_empty() {
+    return stderr.to_string();
+  }
+
+  let stdout = result.stdout.trim();
+  if !stdout.is_empty() {
+    return stdout.to_string();
+  }
+
+  format!("command exited with status {}", result.exit)
+}
+
+fn shell_escape(s: &str) -> String {
+  if s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '/' | ':' | '@')) {
+    s.to_string()
+  } else {
+    format!("'{}'", s.replace('\'', r#"'\''"#))
+  }
 }

--- a/update/src/lib.rs
+++ b/update/src/lib.rs
@@ -338,7 +338,11 @@ pub fn build_github_client(
 // Fetches a specific release from GitHub's API endpoint for the target repo.
 // Callers are expected to apply additional policy checks (draft/published/immutable) before trusting
 // the returned release for installation decisions.
-pub fn fetch_versioned_release(client: &Client, owner_repo: &str, tag_name: &str) -> Result<GhRelease> {
+pub fn fetch_versioned_release(
+    client: &Client,
+    owner_repo: &str,
+    tag_name: &str,
+) -> Result<GhRelease> {
     let url = format!(
         "https://api.github.com/repos/{}/releases/tags/{}",
         owner_repo, tag_name

--- a/update/src/main.rs
+++ b/update/src/main.rs
@@ -1,15 +1,16 @@
 //! SPDX-License-Identifier: GPL-3.0-or-later
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use docopt::Docopt;
 use semver::Version;
 use serde::Deserialize;
-use std::fs;
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use secluso_update::{
     build_github_client, default_signers, download_and_verify_component, fetch_latest_release,
@@ -63,6 +64,46 @@ enum ReleaseSource {
 struct SelectedRelease {
     release: secluso_update::GhRelease,
     source: ReleaseSource,
+}
+
+#[derive(Debug)]
+// Represents a fully prepared binary that is ready to be atomically renamed into place.
+// The install step should commit the exact file we created and filled here.
+// We stage in the destination directory, use exclusive creation, and then rename that same inode into place.
+struct PreparedInstall {
+    tmp_path: PathBuf,
+    final_path: PathBuf,
+}
+
+impl PreparedInstall {
+    fn tmp_path(&self) -> &Path {
+        &self.tmp_path
+    }
+
+    fn final_path(&self) -> &Path {
+        &self.final_path
+    }
+
+    fn commit(self) -> Result<()> {
+        // The rename is the only step that makes the prepared binary live.
+        // Since tmp_path lives in the target directory, this stays on the same filesystem and keeps the swap atomic.
+        fs::rename(&self.tmp_path, &self.final_path).with_context(|| {
+            format!(
+                "installing {} -> {}",
+                self.tmp_path.display(),
+                self.final_path.display()
+            )
+        })?;
+        Ok(())
+    }
+}
+
+impl Drop for PreparedInstall {
+    fn drop(&mut self) {
+        // If anything fails after preparation but before commit, we remove the temp file.
+        // Leaving executable staging junk around isn't exactly great practice.
+        let _ = fs::remove_file(&self.tmp_path);
+    }
 }
 
 fn main() -> ! {
@@ -132,7 +173,8 @@ fn check_update(args: &Args) -> Result<()> {
         require_release_is_immutable,
         |client_version| server_version(client_version),
         |version| fetch_versioned_release(&client, &github_repo, version),
-    )? else {
+    )?
+    else {
         return Ok(());
     };
 
@@ -171,27 +213,23 @@ fn check_update(args: &Args) -> Result<()> {
         verified.component_bytes.len()
     );
 
-    let tmp_path = "/tmp/secluso-binary-tmp";
     let final_path = component.install_path();
-
-    let final_dir = Path::new(&final_path)
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("invalid install path: {}", final_path))?;
-
-    fs::create_dir_all(final_dir)?;
-
-    // Write to a temporary path first and move into place after optional stop/restart sequencing.
-    // reduces partial-write risk on the final install path.
-    fs::write(tmp_path, &verified.component_bytes)?;
-    fs::set_permissions(tmp_path, fs::Permissions::from_mode(0o755))?;
+    // Prepare the binary before we stop the service.
+    // This makes the verified bytes tied to one fresh staging file all the way until rename.
+    let prepared_install =
+        prepare_verified_component_install(Path::new(&final_path), &verified.component_bytes)?;
 
     if let Some(unit) = args.flag_restart_unit.as_deref() {
         println!("Stopping unit: {}", unit);
         run(&format!("systemctl stop {}", shell_escape(unit)));
     }
 
-    println!("Installing: {} -> {}", tmp_path, final_path);
-    fs::rename(tmp_path, &final_path)?;
+    println!(
+        "Installing: {} -> {}",
+        prepared_install.tmp_path().display(),
+        prepared_install.final_path().display()
+    );
+    prepared_install.commit()?;
 
     if let Some(unit) = args.flag_restart_unit.as_deref() {
         println!("Starting unit: {}", unit);
@@ -201,16 +239,108 @@ fn check_update(args: &Args) -> Result<()> {
     // Persist version only after install has succeeded. Acts to gate future update checks (via the marker).
     write_current_version(component, verified.latest_version.clone())?;
 
-    println!("Update completed successfully (component={})", args.flag_component);
+    println!(
+        "Update completed successfully (component={})",
+        args.flag_component
+    );
     Ok(())
 }
 
-fn select_release_for_component<
-    FLatest,
-    FRequireImmutable,
-    FServerVersion,
-    FFetchVersioned,
->(
+fn prepare_verified_component_install(
+    final_path: &Path,
+    component_bytes: &[u8],
+) -> Result<PreparedInstall> {
+    // We prepare the exact file that will later be atomically renamed into the live install path here.
+    // It creates a fresh staging file in the destination directory, writes the verified bytes, applies the executable mode, and syncs the result.
+    // The idea behind this all is that commit later renames the same file we prepared here.
+    let final_dir = final_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("invalid install path: {}", final_path.display()))?;
+
+    fs::create_dir_all(final_dir)
+        .with_context(|| format!("creating install dir {}", final_dir.display()))?;
+
+    let target_name = final_path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "secluso-binary".to_string());
+
+    // Create the temp inode ourselves in the protected target directory with exclusive creation.
+    // *Even if the filename is predictable, create_new refuses to adopt a preexisting file*
+    let (tmp_path, mut tmp_file) = create_secure_install_temp_file(final_dir, &target_name)?;
+
+    let write_result = (|| -> Result<()> {
+        // All writes happen through the file descriptor returned by the exclusive open above.
+        // That keeps the verified bytes attached to the same inode we later rename.
+        tmp_file
+            .write_all(component_bytes)
+            .with_context(|| format!("writing verified binary to {}", tmp_path.display()))?;
+        // Start from 0600 and only mark the file executable after the verified bytes are fully written.
+        // (this avoids exposing a half-written executable if something goes sideways)
+        tmp_file
+            .set_permissions(fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("setting executable mode on {}", tmp_path.display()))?;
+        // Flush file contents and metadata before rename; keeps the final swap from depending on dirty cache state.
+        tmp_file
+            .sync_all()
+            .with_context(|| format!("syncing prepared binary at {}", tmp_path.display()))?;
+        Ok(())
+    })();
+
+    if let Err(err) = write_result {
+        drop(tmp_file);
+        let _ = fs::remove_file(&tmp_path);
+        return Err(err);
+    }
+
+    drop(tmp_file);
+
+    Ok(PreparedInstall {
+        tmp_path,
+        final_path: final_path.to_path_buf(),
+    })
+}
+
+fn create_secure_install_temp_file(
+    final_dir: &Path,
+    target_name: &str,
+) -> Result<(PathBuf, fs::File)> {
+    // We only generate a unique name here so retries do not trip over each other.
+    // Actual safety comes from create_new in the target directory and then sticking with that fd for the whole write.
+    let seed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+
+    for attempt in 0..128u32 {
+        let tmp_path = final_dir.join(format!(
+            ".{target_name}.install.{}.{}.tmp",
+            std::process::id(),
+            seed + u128::from(attempt)
+        ));
+
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp_path)
+        {
+            Ok(file) => return Ok((tmp_path, file)),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("creating temp install path {}", tmp_path.display()));
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "failed to allocate a unique install temp path in {}",
+        final_dir.display()
+    ))
+}
+
+fn select_release_for_component<FLatest, FRequireImmutable, FServerVersion, FFetchVersioned>(
     component: Component,
     current_version: &Version,
     fetch_latest_release_fn: FLatest,
@@ -269,6 +399,86 @@ fn run(cmd: &str) {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(prefix: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "{prefix}-{}-{}",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn prepared_install_commit_replaces_binary_without_temp_leftovers() {
+        let root = TestDir::new("secluso-update-install");
+        let final_path = root.path().join("bin").join("secluso-server");
+
+        let prepared =
+            prepare_verified_component_install(&final_path, b"verified-server-binary").unwrap();
+
+        assert!(prepared.tmp_path().exists());
+        assert_eq!(prepared.final_path(), final_path.as_path());
+
+        prepared.commit().unwrap();
+
+        // After commit, only the final binary should remain in the directory.
+        assert_eq!(fs::read(&final_path).unwrap(), b"verified-server-binary");
+        assert_eq!(
+            fs::metadata(&final_path).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+
+        let entries = fs::read_dir(final_path.parent().unwrap())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().into_string().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec!["secluso-server".to_string()]);
+    }
+
+    #[test]
+    fn dropping_prepared_install_cleans_up_temp_file() {
+        let root = TestDir::new("secluso-update-cleanup");
+        let final_path = root.path().join("bin").join("secluso-server");
+
+        let tmp_path = {
+            let prepared =
+                prepare_verified_component_install(&final_path, b"verified-server-binary").unwrap();
+            let tmp_path = prepared.tmp_path().to_path_buf();
+            assert!(tmp_path.exists());
+            tmp_path
+        };
+
+        // If installation aborts after the temp inode is created, cleanup should remove it, so that we don't accumulate executable staging files in the protected install directory.
+        assert!(!tmp_path.exists());
+        assert!(!final_path.exists());
+    }
 }
 
 // Minimal shell escaping helper to safely embed unit names into sh -c commands.


### PR DESCRIPTION
This hardens how we stage verified binaries before installing them in both the updater and the deploy provisioning flow.

The first commit updates the local updater path so verified binaries are staged through a freshly created temporary file in the target directory and then atomically renamed into place. The second commit updates deploy provisioning so remote install inputs are staged in a per-run temporary directory and taken from there instead of from shared fixed temporary paths.

Basically, both changes make sure we install from fresh staging files created for the current run instead of trusting shared temp paths.
