### PR TITLE
Generate credentials needed for testing with the app_native's example app.

### DIFF
--- a/client_server_lib/src/auth.rs
+++ b/client_server_lib/src/auth.rs
@@ -86,12 +86,15 @@ pub fn generate_random(num_chars: usize, special_characters: bool) -> String {
         .collect()
 }
 
-pub fn create_user_credentials(server_addr: String) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+pub fn create_user_credentials(server_addr: String) -> anyhow::Result<(Vec<u8>, Vec<u8>, Vec<u8>)> {
     let username = generate_random(NUM_USERNAME_CHARS, true);
     let password = generate_random(NUM_PASSWORD_CHARS, true);
 
     let credentials_string = format!("{}{}", username, password);
     let credentials = credentials_string.into_bytes();
+
+    let credentials_full_testing_string = format!("{}{}{}", username, password, server_addr);
+    let credentials_full_testing = credentials_full_testing_string.into_bytes();
 
     let user_credentials = UserCredentials {
         version: USER_CREDENTIALS_VERSION.to_string(),
@@ -102,6 +105,6 @@ pub fn create_user_credentials(server_addr: String) -> anyhow::Result<(Vec<u8>, 
     let credentials_full_string = serde_json::to_string(&user_credentials)
         .context("Failed to serialize user credentials into JSON")?;
     let credentials_full = credentials_full_string.into_bytes();
-
-    Ok((credentials, credentials_full))
+    
+    Ok((credentials, credentials_full, credentials_full_testing))
 }

--- a/config_tool/src/main.rs
+++ b/config_tool/src/main.rs
@@ -86,7 +86,7 @@ fn generate_user_credentials(dir: &Path, mut server_addr: &str) -> anyhow::Resul
     server_addr = server_addr.trim_end_matches('/');
 
 
-    let (credentials, credentials_full) =
+    let (credentials, credentials_full, credentials_full_testing) =
         create_user_credentials(server_addr.to_string())?;
 
     // Create the directory if it doesn't exist
@@ -105,9 +105,9 @@ fn generate_user_credentials(dir: &Path, mut server_addr: &str) -> anyhow::Resul
         .context("Failed to save image")?;
 
     // Save the credentials_full in a file to be used for testing with the example app
-    // let mut file =
-    //     fs::File::create(dir.clone() + "/user_credentials_for_testing").expect("Could not create file");
-    // let _ = file.write_all(&credentials_full);
+    let mut file =
+        fs::File::create(dir.join("user_credentials_for_testing")).expect("Could not create file");
+    let _ = file.write_all(&credentials_full_testing);
 
     Ok(())
 }

--- a/deploy/src-tauri/src/pi_hub_provision/credentials.rs
+++ b/deploy/src-tauri/src/pi_hub_provision/credentials.rs
@@ -39,7 +39,7 @@ pub fn generate_user_credentials_only(
     fs::create_dir_all(work_path).with_context(|| format!("creating work dir {}", work_path.display()))?;
 
     let normalized_url = normalize_server_url(server_url)?;
-    let (credentials, credentials_full) = create_user_credentials(normalized_url)?;
+    let (credentials, credentials_full, _) = create_user_credentials(normalized_url)?;
 
     fs::write(work_path.join("user_credentials"), credentials)
         .with_context(|| format!("writing {}", work_path.join("user_credentials").display()))?;


### PR DESCRIPTION
The config tool currently generates a credentials_full QR code for the mobile app. For the example app, there's no need to use a QR code. Instead, we generate and use a text-based version of credentials_full.