### PR TITLE
Force-derive thumbnail filename via timestamp

### DIFF
--- a/camera_hub/src/delivery_monitor.rs
+++ b/camera_hub/src/delivery_monitor.rs
@@ -278,7 +278,7 @@ impl DeliveryMonitor {
 
     pub fn get_thumbnail_file_path(&self, info: &ThumbnailMetaInfo) -> PathBuf {
         let video_dir_path = Path::new(&self.thumbnail_dir);
-        video_dir_path.join(&info.filename)
+        video_dir_path.join(ThumbnailMetaInfo::get_filename_from_timestamp(info.timestamp))
     }
 
     pub fn get_enc_video_file_path(&self, info: &VideoInfo) -> PathBuf {

--- a/camera_hub/src/main.rs
+++ b/camera_hub/src/main.rs
@@ -475,8 +475,9 @@ fn core(
                 info!("Starting to save and send video thumbnail");
                 let thumbnail_info =
                     ThumbnailMetaInfo::new(video_info.timestamp, 0, motion_event.detections); //0 epoch = unset
-                let thumbnail_file =
-                    camera.get_thumbnail_dir() + "/" + &*thumbnail_info.filename.clone();
+                let thumbnail_file = camera.get_thumbnail_dir()
+                    + "/"
+                    + &ThumbnailMetaInfo::get_filename_from_timestamp(thumbnail_info.timestamp);
                 thumbnail_image
                     .save(thumbnail_file)
                     .expect("Failed to save thumbnail PNG file");

--- a/client_lib/src/thumbnail_meta_info.rs
+++ b/client_lib/src/thumbnail_meta_info.rs
@@ -16,7 +16,6 @@ pub struct ThumbnailMetaInfo {
     pub detections: Vec<GeneralDetectionType>,
     pub sanity: String,
     pub epoch: u64,
-    pub filename: String,
 }
 
 pub const THUMBNAIL_SANITY: &str = "thumbbeef";
@@ -32,7 +31,6 @@ impl ThumbnailMetaInfo {
             detections,
             sanity: THUMBNAIL_SANITY.to_string(),
             epoch: thumbnail_epoch,
-            filename: Self::get_filename_from_timestamp(timestamp),
         }
     }
 

--- a/client_lib/src/video.rs
+++ b/client_lib/src/video.rs
@@ -168,7 +168,9 @@ pub fn decrypt_thumbnail_file(
         }
     }
 
-    let dec_filename: String = thumbnail_meta_info.filename;
+    // Do not trust the sender-provided filename here.
+    // The timestamp is the stable identifier for thumbnails, and deriving the path from it prevents path traversal through attacker-crafted metadata.
+    let dec_filename = ThumbnailMetaInfo::get_filename_from_timestamp(thumbnail_meta_info.timestamp);
     let dec_pathname: String = format!("{}/videos/{}", file_dir, dec_filename);
 
     if Path::new(&dec_pathname).exists() {


### PR DESCRIPTION
This stops trusting sender-controlled thumbnail filenames. Instead, the app derives thumbnail filenames from the timestamp using a fixed format.