### PR TITLE
Put a cap on socket receive size.

### DIFF
--- a/app_native/examples/app.rs
+++ b/app_native/examples/app.rs
@@ -13,7 +13,7 @@ use secluso_app_native::{
     get_key_packages, decrypt_thumbnail,
 };
 use secluso_client_lib::http_client::HttpClient;
-use secluso_client_lib::pairing::NUM_SECRET_BYTES;
+use secluso_client_lib::pairing::{NUM_SECRET_BYTES};
 use secluso_client_server_lib::auth::parse_user_credentials_full;
 use secluso_client_lib::mls_clients::{MOTION, THUMBNAIL, NUM_MLS_CLIENTS};
 use docopt::Docopt;
@@ -28,6 +28,7 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::net::{TcpListener, TcpStream, SocketAddr};
 use std::str::FromStr;
+use std::io::ErrorKind;
 
 // This is a simple app that pairs with the Secluso camera, receives motion videos,
 // and launches livestream sessions.
@@ -41,6 +42,8 @@ const CAMERA_ADDR: &str = "127.0.0.1";
 const CAMERA_NAME: &str = "Camera";
 const DATA_DIR: &str = "example_app_data";
 const FIRST_APP_ADDR: &str = "127.0.0.1";
+
+pub const MAX_ALLOWED_MSG_LEN: u64 = 65536;
 
 const USAGE: &str = "
 Runs a simple Secluso app.
@@ -535,8 +538,6 @@ fn write_varying_len(stream: &mut TcpStream, msg: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
-use std::io::ErrorKind;
-
 fn read_varying_len(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
     let mut len_data = [0u8; 8];
 
@@ -552,6 +553,15 @@ fn read_varying_len(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
     }
 
     let len = u64::from_be_bytes(len_data);
+
+    if len > MAX_ALLOWED_MSG_LEN {
+        println!("Communicated message length ({len}) exceeds the allowed length ({MAX_ALLOWED_MSG_LEN})");
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "Intended message length is too large",
+        ))
+    }
+
     let mut msg = vec![0u8; len as usize];
     let mut offset = 0;
 

--- a/app_native/src/lib.rs
+++ b/app_native/src/lib.rs
@@ -4,7 +4,7 @@
 
 use anyhow::anyhow;
 use anyhow::Context;
-use log::{debug, error};
+use log::{debug, error, info};
 use rand::Rng;
 use secluso_client_lib::config::{
     Heartbeat, HeartbeatRequest, HeartbeatResult, OPCODE_HEARTBEAT_REQUEST, OPCODE_HEARTBEAT_RESPONSE,
@@ -16,7 +16,7 @@ use secluso_client_lib::mls_clients::{
     CONFIG, FCM, LIVESTREAM, MLS_CLIENT_TAGS, MOTION, NUM_MLS_CLIENTS, THUMBNAIL,
     NUM_COMMON_MLS_CLIENTS, NUM_DEDICATED_MLS_CLIENTS,
 };
-use secluso_client_lib::pairing;
+use secluso_client_lib::pairing::{self, MAX_ALLOWED_MSG_LEN};
 use secluso_client_lib::video::{encrypt_video_file, decrypt_video_file, decrypt_thumbnail_file};
 use openmls::prelude::KeyPackage;
 use serde::{Deserialize, Serialize};
@@ -31,7 +31,7 @@ use std::str;
 use std::str::FromStr;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use log::info;
+use std::io::ErrorKind;
 
 // Used to generate random names.
 // With 16 alphanumeric characters, the probability of collision is very low.
@@ -120,6 +120,14 @@ fn read_varying_len(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
     let mut len_data = [0u8; 8];
     stream.read_exact(&mut len_data)?;
     let len = u64::from_be_bytes(len_data);
+
+    if len > MAX_ALLOWED_MSG_LEN {
+        error!("Communicated message length ({len}) exceeds the allowed length ({MAX_ALLOWED_MSG_LEN})");
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "Intended message length is too large",
+        ))
+    }
 
     let mut msg = vec![0u8; len as usize];
     stream.read_exact(&mut msg)?;

--- a/camera_hub/src/pairing.rs
+++ b/camera_hub/src/pairing.rs
@@ -11,8 +11,7 @@ use rand::Rng;
 use secluso_client_lib::http_client::HttpClient;
 use secluso_client_lib::mls_client::MlsClient;
 use secluso_client_lib::mls_clients::{MlsClients, CONFIG};
-use secluso_client_lib::pairing;
-use secluso_client_lib::pairing::generate_ip_camera_secret;
+use secluso_client_lib::pairing::{self, generate_ip_camera_secret, MAX_ALLOWED_MSG_LEN};
 use secluso_client_server_lib::auth::parse_user_credentials_full;
 use serde_json::Value;
 use std::fs;
@@ -26,6 +25,7 @@ use std::process::{Command, Stdio};
 use std::sync::{Mutex, OnceLock};
 use std::{thread, time::Duration};
 use url::Url;
+use std::io::ErrorKind;
 
 // Used to generate random names.
 // With 16 alphanumeric characters, the probability of collision is very low.
@@ -49,8 +49,6 @@ fn write_varying_len(stream: &mut TcpStream, msg: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
-use std::io::ErrorKind;
-
 fn read_varying_len(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
     let mut len_data = [0u8; 8];
 
@@ -66,6 +64,15 @@ fn read_varying_len(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
     }
 
     let len = u64::from_be_bytes(len_data);
+
+    if len > MAX_ALLOWED_MSG_LEN {
+        error!("Communicated message length ({len}) exceeds the allowed length ({MAX_ALLOWED_MSG_LEN})");
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "Intended message length is too large",
+        ))
+    }
+
     let mut msg = vec![0u8; len as usize];
     let mut offset = 0;
 

--- a/client_lib/src/pairing.rs
+++ b/client_lib/src/pairing.rs
@@ -22,6 +22,7 @@ use rand::{Rng, thread_rng};
 pub const NUM_SECRET_BYTES: usize = 72;
 pub const CAMERA_SECRET_VERSION: &str = "v1.2";
 const WIFI_PASSWORD_LEN: usize = 10;
+pub const MAX_ALLOWED_MSG_LEN: u64 = 8192;
 
 // We version the QR code, store secret bytes as well (base64-url-encoded) as the Wi-Fi passphrase for Raspberry Pi cameras.
 // Versioned QR codes can be helpful to ensure compatibility.


### PR DESCRIPTION
The app and camera exchange some messages on a socket during the pairing process. The second example app also exchanges messages with the first one over a socket. We put a cap on how much data can be read from the socket in each transaction. This will limit the size of the buffer that will be allocated for reading the message.