### PR TITLE
Harden notification target handling against SSRF and path traversal

### DIFF
--- a/camera_hub/src/notification_target.rs
+++ b/camera_hub/src/notification_target.rs
@@ -2,14 +2,12 @@
 //!
 //! SPDX-License-Identifier: GPL-3.0-or-later
 
-use secluso_client_lib::http_client::{HttpClient, IosRelayBinding, NotificationTarget};
+use secluso_client_lib::http_client::{validate_ios_relay_binding, HttpClient, NotificationTarget};
 use std::fs;
 use std::io;
 use std::path::Path;
-use url::Url;
 
 const TARGET_FILENAME: &str = "notification_target.json";
-const TRUSTED_IOS_RELAY_HOSTS: &[&str] = &["relay.secluso.com", "testing-relay.secluso.com"];
 
 // Build the placeholder target we keep for iOS while no relay binding is available / after the current binding has been rejected.
 fn ios_placeholder_target(platform: &str) -> NotificationTarget {
@@ -20,80 +18,6 @@ fn ios_placeholder_target(platform: &str) -> NotificationTarget {
         unifiedpush_pub_key: None,
         unifiedpush_auth: None,
     }
-}
-
-// Mirror the server-side relay checks before the hub sends any outbound iOS request.
-// Ensures a malicious/stale notification target cannot turn the hub into a generic HTTPS client.
-fn validate_ios_relay_base_url(raw_url: &str) -> io::Result<Url> {
-    let parsed = Url::parse(raw_url)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
-    if parsed.scheme() != "https" {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "iOS relay base URL must use https",
-        ));
-    }
-    if !parsed.username().is_empty() || parsed.password().is_some() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "iOS relay base URL must not include credentials",
-        ));
-    }
-    if parsed.query().is_some() || parsed.fragment().is_some() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "iOS relay base URL must not include a query or fragment",
-        ));
-    }
-    if parsed.path() != "/" {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "iOS relay base URL must not include a path prefix",
-        ));
-    }
-
-    let host = parsed.host_str().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "iOS relay base URL is missing a host",
-        )
-    })?;
-    let port = parsed.port_or_known_default().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "iOS relay base URL is missing an https port",
-        )
-    })?;
-    if port != 443 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "iOS relay base URL must use the default https port",
-        ));
-    }
-    if !TRUSTED_IOS_RELAY_HOSTS
-        .iter()
-        .any(|allowed| host.eq_ignore_ascii_case(allowed))
-    {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("Refusing unexpected iOS relay host: {host}"),
-        ));
-    }
-
-    Ok(parsed)
-}
-
-fn validate_ios_relay_binding(binding: &IosRelayBinding) -> io::Result<()> {
-    let relay_base = binding.relay_base_url.trim();
-    if relay_base.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "iOS relay base URL is required",
-        ));
-    }
-    validate_ios_relay_base_url(relay_base)?;
-
-    Ok(())
 }
 
 pub fn persist_notification_target(state_dir: &str, target: &NotificationTarget) -> io::Result<()> {
@@ -205,49 +129,4 @@ pub fn send_notification(
     }
 
     http_client.send_fcm_notification(notification_msg)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{validate_ios_relay_base_url, validate_ios_relay_binding};
-    use secluso_client_lib::http_client::IosRelayBinding;
-
-    // Build an otherwise-valid relay binding and let each test vary only the relay base URL it wants to validate.
-    fn ios_binding(relay_base_url: &str) -> IosRelayBinding {
-        IosRelayBinding {
-            relay_base_url: relay_base_url.to_string(),
-            hub_token: "hub-token".to_string(),
-            app_install_id: "install-id".to_string(),
-            hub_id: "hub-id".to_string(),
-            device_token: "device-token".to_string(),
-            expires_at_epoch_ms: 1,
-        }
-    }
-
-    #[test]
-    // Tests that the camera hub accepts the public production relay.
-    fn accepts_trusted_ios_relay_host() {
-        validate_ios_relay_base_url("https://relay.secluso.com")
-            .expect("trusted relay host should be accepted");
-    }
-
-    #[test]
-    // Tests that server-side iOS relay checks reject unexpected relay hosts before the target can be persisted to the hub.
-    fn rejects_untrusted_ios_relay_host() {
-        let err = validate_ios_relay_base_url("https://evil.example")
-            .expect_err("unexpected relay host should be rejected");
-
-        assert!(err
-            .to_string()
-            .contains("Refusing unexpected iOS relay host"));
-    }
-
-    #[test]
-    // Tests that the binding-level check rejects incomplete relay bindings before send_notification hands them to the HTTP client.
-    fn rejects_empty_ios_relay_base_url() {
-        let err = validate_ios_relay_binding(&ios_binding("   "))
-            .expect_err("empty relay base URL should be rejected");
-
-        assert!(err.to_string().contains("iOS relay base URL is required"));
-    }
 }

--- a/camera_hub/src/notification_target.rs
+++ b/camera_hub/src/notification_target.rs
@@ -2,12 +2,99 @@
 //!
 //! SPDX-License-Identifier: GPL-3.0-or-later
 
-use secluso_client_lib::http_client::{HttpClient, NotificationTarget};
+use secluso_client_lib::http_client::{HttpClient, IosRelayBinding, NotificationTarget};
 use std::fs;
 use std::io;
 use std::path::Path;
+use url::Url;
 
 const TARGET_FILENAME: &str = "notification_target.json";
+const TRUSTED_IOS_RELAY_HOSTS: &[&str] = &["relay.secluso.com", "testing-relay.secluso.com"];
+
+// Build the placeholder target we keep for iOS while no relay binding is available / after the current binding has been rejected.
+fn ios_placeholder_target(platform: &str) -> NotificationTarget {
+    NotificationTarget {
+        platform: platform.to_string(),
+        ios_relay_binding: None,
+        unifiedpush_endpoint_url: None,
+        unifiedpush_pub_key: None,
+        unifiedpush_auth: None,
+    }
+}
+
+// Mirror the server-side relay checks before the hub sends any outbound iOS request.
+// Ensures a malicious/stale notification target cannot turn the hub into a generic HTTPS client.
+fn validate_ios_relay_base_url(raw_url: &str) -> io::Result<Url> {
+    let parsed = Url::parse(raw_url)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    if parsed.scheme() != "https" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL must use https",
+        ));
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL must not include credentials",
+        ));
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL must not include a query or fragment",
+        ));
+    }
+    if parsed.path() != "/" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL must not include a path prefix",
+        ));
+    }
+
+    let host = parsed.host_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL is missing a host",
+        )
+    })?;
+    let port = parsed.port_or_known_default().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL is missing an https port",
+        )
+    })?;
+    if port != 443 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL must use the default https port",
+        ));
+    }
+    if !TRUSTED_IOS_RELAY_HOSTS
+        .iter()
+        .any(|allowed| host.eq_ignore_ascii_case(allowed))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Refusing unexpected iOS relay host: {host}"),
+        ));
+    }
+
+    Ok(parsed)
+}
+
+fn validate_ios_relay_binding(binding: &IosRelayBinding) -> io::Result<()> {
+    let relay_base = binding.relay_base_url.trim();
+    if relay_base.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL is required",
+        ));
+    }
+    validate_ios_relay_base_url(relay_base)?;
+
+    Ok(())
+}
 
 pub fn persist_notification_target(state_dir: &str, target: &NotificationTarget) -> io::Result<()> {
     fs::create_dir_all(state_dir)?;
@@ -55,13 +142,7 @@ pub fn refresh_notification_target(
             });
             if let Some(target) = cached {
                 if target.platform.eq_ignore_ascii_case("ios") {
-                    let placeholder = NotificationTarget {
-                        platform: target.platform.clone(),
-                        ios_relay_binding: None,
-                        unifiedpush_endpoint_url: None,
-                        unifiedpush_pub_key: None,
-                        unifiedpush_auth: None,
-                    };
+                    let placeholder = ios_placeholder_target(&target.platform);
                     if let Err(e) = persist_notification_target(state_dir, &placeholder) {
                         error!("Failed to persist iOS notification placeholder: {e}");
                     }
@@ -93,16 +174,20 @@ pub fn send_notification(
     if let Some(target) = target {
         if target.platform.eq_ignore_ascii_case("ios") {
             if let Some(binding) = target.ios_relay_binding.as_ref() {
+                if let Err(e) = validate_ios_relay_binding(binding) {
+                    let placeholder = ios_placeholder_target(&target.platform);
+                    if let Err(clear_err) = persist_notification_target(state_dir, &placeholder) {
+                        error!(
+                            "Failed to persist iOS notification placeholder after relay validation failure: {clear_err}"
+                        );
+                    }
+                    return Err(e);
+                }
+
                 let result = http_client.send_ios_notification(notification_msg, binding);
                 if let Err(e) = result.as_ref() {
                     if e.to_string().contains("Relay error: 403") {
-                        let placeholder = NotificationTarget {
-                            platform: target.platform.clone(),
-                            ios_relay_binding: None,
-                            unifiedpush_endpoint_url: None,
-                            unifiedpush_pub_key: None,
-                            unifiedpush_auth: None,
-                        };
+                        let placeholder = ios_placeholder_target(&target.platform);
                         if let Err(clear_err) = persist_notification_target(state_dir, &placeholder)
                         {
                             error!(
@@ -120,4 +205,49 @@ pub fn send_notification(
     }
 
     http_client.send_fcm_notification(notification_msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_ios_relay_base_url, validate_ios_relay_binding};
+    use secluso_client_lib::http_client::IosRelayBinding;
+
+    // Build an otherwise-valid relay binding and let each test vary only the relay base URL it wants to validate.
+    fn ios_binding(relay_base_url: &str) -> IosRelayBinding {
+        IosRelayBinding {
+            relay_base_url: relay_base_url.to_string(),
+            hub_token: "hub-token".to_string(),
+            app_install_id: "install-id".to_string(),
+            hub_id: "hub-id".to_string(),
+            device_token: "device-token".to_string(),
+            expires_at_epoch_ms: 1,
+        }
+    }
+
+    #[test]
+    // Tests that the camera hub accepts the public production relay.
+    fn accepts_trusted_ios_relay_host() {
+        validate_ios_relay_base_url("https://relay.secluso.com")
+            .expect("trusted relay host should be accepted");
+    }
+
+    #[test]
+    // Tests that server-side iOS relay checks reject unexpected relay hosts before the target can be persisted to the hub.
+    fn rejects_untrusted_ios_relay_host() {
+        let err = validate_ios_relay_base_url("https://evil.example")
+            .expect_err("unexpected relay host should be rejected");
+
+        assert!(err
+            .to_string()
+            .contains("Refusing unexpected iOS relay host"));
+    }
+
+    #[test]
+    // Tests that the binding-level check rejects incomplete relay bindings before send_notification hands them to the HTTP client.
+    fn rejects_empty_ios_relay_base_url() {
+        let err = validate_ios_relay_binding(&ios_binding("   "))
+            .expect_err("empty relay base URL should be rejected");
+
+        assert!(err.to_string().contains("iOS relay base URL is required"));
+    }
 }

--- a/client_lib/src/http_client.rs
+++ b/client_lib/src/http_client.rs
@@ -5,6 +5,7 @@
 use base64::engine::general_purpose::STANDARD as base64_engine;
 use base64::{engine::general_purpose, Engine as _};
 use reqwest::blocking::{Body, Client, RequestBuilder};
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs::File;
@@ -57,11 +58,85 @@ pub struct PairingStatus {
     pub notification_target: Option<NotificationTarget>,
 }
 
+const TRUSTED_IOS_RELAY_HOSTS: &[&str] = &["relay.secluso.com", "testing-relay.secluso.com"];
+
 //TODO: There's a lot of repitition between the functions here.
 
 // Note: The server needs a unique name for each camera.
 // The name needs to be available to both the camera and the app.
 // We use the MLS group name for that purpose.
+
+// Mirror the server-side relay checks before the hub sends any outbound iOS request.
+// Ensures a malicious/stale notification target cannot turn the hub into a generic HTTPS client.
+fn validate_ios_relay_base_url(raw_url: &str) -> io::Result<Url> {
+    let parsed = Url::parse(raw_url)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    if parsed.scheme() != "https" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL must use https",
+        ));
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL must not include credentials",
+        ));
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL must not include a query or fragment",
+        ));
+    }
+    if parsed.path() != "/" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL must not include a path prefix",
+        ));
+    }
+
+    let host = parsed.host_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL is missing a host",
+        )
+    })?;
+    let port = parsed.port_or_known_default().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL is missing an https port",
+        )
+    })?;
+    if port != 443 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL must use the default https port",
+        ));
+    }
+    if !TRUSTED_IOS_RELAY_HOSTS
+        .iter()
+        .any(|allowed| host.eq_ignore_ascii_case(allowed))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Refusing unexpected iOS relay host: {host}"),
+        ));
+    }
+
+    Ok(parsed)
+}
+
+pub fn validate_ios_relay_binding(binding: &IosRelayBinding) -> io::Result<Url> {
+    let relay_base = binding.relay_base_url.trim();
+    if relay_base.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "iOS relay base URL is required",
+        ));
+    }
+    validate_ios_relay_base_url(relay_base)
+}
 
 impl HttpClient {
     pub fn authorized_headers(&self, request_builder: RequestBuilder) -> RequestBuilder {
@@ -168,14 +243,10 @@ impl HttpClient {
     ) -> io::Result<()> {
         const IOS_RELAY_USER_AGENT: &str = "SeclusoCameraHub/1.0";
 
-        let relay_base = binding.relay_base_url.trim_end_matches('/');
-        if !relay_base.starts_with("https://") {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Relay base URL must use https",
-            ));
-        }
-        let relay_url = format!("{relay_base}/hub/notify");
+        let relay_base = validate_ios_relay_binding(binding)?;
+        let relay_url = relay_base
+            .join("hub/notify")
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
         let payload = json!({
             "hub_token": binding.hub_token,
@@ -198,7 +269,7 @@ impl HttpClient {
 
         // This does NOT need authorized_headers as it's a separate relay (public Secluso iOS relay)
         let response = client
-            .post(&relay_url)
+            .post(relay_url)
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
             .header("User-Agent", IOS_RELAY_USER_AGENT)
@@ -734,5 +805,49 @@ impl HttpClient {
         }
 
         Ok(response_vec)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_ios_relay_base_url, validate_ios_relay_binding, IosRelayBinding};
+
+    // Build an otherwise-valid relay binding and let each test vary only the relay base URL it wants to validate.
+    fn ios_binding(relay_base_url: &str) -> IosRelayBinding {
+        IosRelayBinding {
+            relay_base_url: relay_base_url.to_string(),
+            hub_token: "hub-token".to_string(),
+            app_install_id: "install-id".to_string(),
+            hub_id: "hub-id".to_string(),
+            device_token: "device-token".to_string(),
+            expires_at_epoch_ms: 1,
+        }
+    }
+
+    #[test]
+    // Tests that the camera hub accepts the public production relay.
+    fn accepts_trusted_ios_relay_host() {
+        validate_ios_relay_base_url("https://relay.secluso.com")
+            .expect("trusted relay host should be accepted");
+    }
+
+    #[test]
+    // Tests that server-side iOS relay checks reject unexpected relay hosts before the target can be persisted to the hub.
+    fn rejects_untrusted_ios_relay_host() {
+        let err = validate_ios_relay_base_url("https://evil.example")
+            .expect_err("unexpected relay host should be rejected");
+
+        assert!(err
+            .to_string()
+            .contains("Refusing unexpected iOS relay host"));
+    }
+
+    #[test]
+    // Tests that the binding-level check rejects incomplete relay bindings before send_notification hands them to the HTTP client.
+    fn rejects_empty_ios_relay_base_url() {
+        let err = validate_ios_relay_binding(&ios_binding("   "))
+            .expect_err("empty relay base URL should be rejected");
+
+        assert!(err.to_string().contains("iOS relay base URL is required"));
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -46,7 +46,7 @@ pub mod unifiedpush;
 
 use self::auth::{initialize_users, BasicAuth, FailStore};
 use self::fcm::send_notification;
-use self::security::check_path_sandboxed;
+use self::security::{check_path_sandboxed, join_validated_child};
 
 // Store the version of the current crate, which we'll use in all responses.
 #[derive(Default, Clone)]
@@ -362,7 +362,7 @@ async fn upload(
     }
 
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera")?;
     check_path_sandboxed(&root, &camera_path)?;
 
     if !camera_path.exists() {
@@ -417,7 +417,10 @@ async fn bulk_group_check(data: Json<MotionPairs>, auth: &BasicAuth) -> Json<Vec
         let group_name = pair.group_name;
         let epoch_to_check = pair.epoch_to_check;
 
-        let camera_path = root.join(&group_name);
+        let camera_path = match join_validated_child(&root, &group_name, "camera") {
+            Ok(path) => path,
+            Err(_) => continue,
+        };
         if check_path_sandboxed(&root, &camera_path).is_err() {
             continue;
         }
@@ -450,7 +453,7 @@ async fn bulk_group_check(data: Json<MotionPairs>, auth: &BasicAuth) -> Json<Vec
 #[get("/<camera>/<filename>")]
 async fn retrieve(camera: &str, filename: &str, auth: &BasicAuth) -> Option<RawText<File>> {
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera").ok()?;
     if check_path_sandboxed(&root, &camera_path).is_err() {
         return None;
     }
@@ -482,7 +485,7 @@ async fn remove_file_lock(camera: &str) {
 #[delete("/<camera>/<filename>")]
 async fn delete_file(camera: &str, filename: &str, auth: &BasicAuth) -> Option<()> {
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera").ok()?;
 
     if check_path_sandboxed(&root, &camera_path).is_err() {
         return None;
@@ -543,7 +546,7 @@ async fn delete_file(camera: &str, filename: &str, auth: &BasicAuth) -> Option<(
 #[delete("/<camera>")]
 async fn delete_camera(camera: &str, auth: &BasicAuth) -> io::Result<()> {
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera")?;
     check_path_sandboxed(&root, &camera_path)?;
 
     remove_file_lock(camera).await;
@@ -700,7 +703,7 @@ async fn livestream_start(
     all_state: &rocket::State<AllEventState>,
 ) -> io::Result<()> {
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera")?;
     check_path_sandboxed(&root, &camera_path)?;
 
     if !camera_path.exists() {
@@ -742,13 +745,21 @@ async fn livestream_check(
     let camera = camera.to_string();
 
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(&camera);
+    let camera_path = join_validated_child(&root, &camera, "camera");
 
     let user_state = get_user_state(all_state.inner().clone(), &auth.username);
     let mut rx = user_state.sender.subscribe();
 
     EventStream! {
-        if check_path_sandboxed(&root, &camera_path).is_err() {
+        let camera_path = match camera_path.as_ref() {
+            Ok(path) => path,
+            Err(_) => {
+                yield Event::data("invalid");
+                return;
+            }
+        };
+
+        if check_path_sandboxed(&root, camera_path).is_err() {
             yield Event::data("invalid");
             return;
         }
@@ -783,7 +794,7 @@ async fn livestream_upload(
     all_state: &rocket::State<AllEventState>,
 ) -> io::Result<String> {
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera")?;
     check_path_sandboxed(&root, &camera_path)?;
 
     if !camera_path.exists() {
@@ -844,7 +855,7 @@ async fn livestream_retrieve(
     all_state: &rocket::State<AllEventState>,
 ) -> Option<RawText<File>> {
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera").ok()?;
     if check_path_sandboxed(&root, &camera_path).is_err() {
         return None;
     }
@@ -888,7 +899,7 @@ async fn livestream_retrieve(
 #[post("/livestream_end/<camera>")]
 async fn livestream_end(camera: &str, auth: &BasicAuth) -> io::Result<()> {
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera")?;
     check_path_sandboxed(&root, &camera_path)?;
 
     if !camera_path.exists() {
@@ -911,7 +922,7 @@ async fn config_command(
     all_state: &rocket::State<AllEventState>,
 ) -> io::Result<()> {
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera")?;
     check_path_sandboxed(&root, &camera_path)?;
 
     if !camera_path.exists() {
@@ -949,13 +960,21 @@ async fn config_check(
     let camera = camera.to_string();
 
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(&camera);
+    let camera_path = join_validated_child(&root, &camera, "camera");
 
     let user_state = get_user_state(all_state.inner().clone(), &auth.username);
     let mut rx = user_state.sender.subscribe();
 
     EventStream! {
-        if check_path_sandboxed(&root, &camera_path).is_err() {
+        let camera_path = match camera_path.as_ref() {
+            Ok(path) => path,
+            Err(_) => {
+                yield Event::data("invalid");
+                return;
+            }
+        };
+
+        if check_path_sandboxed(&root, camera_path).is_err() {
             yield Event::data("invalid");
             return;
         }
@@ -998,7 +1017,7 @@ async fn config_check(
 #[post("/config_response/<camera>", data = "<data>")]
 async fn config_response(camera: &str, data: Data<'_>, auth: &BasicAuth) -> io::Result<()> {
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera")?;
     check_path_sandboxed(&root, &camera_path)?;
 
     if !camera_path.exists() {
@@ -1030,7 +1049,7 @@ async fn config_response(camera: &str, data: Data<'_>, auth: &BasicAuth) -> io::
 #[get("/config_response/<camera>")]
 async fn retrieve_config_response(camera: &str, auth: &BasicAuth) -> Option<RawText<File>> {
     let root = Path::new("data").join(&auth.username);
-    let camera_path = root.join(camera);
+    let camera_path = join_validated_child(&root, camera, "camera").ok()?;
     if check_path_sandboxed(&root, &camera_path).is_err() {
         return None;
     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -252,7 +252,7 @@ async fn pair(
                         unifiedpush_policy.inner(),
                         &target,
                     ) {
-                        warn!("Dropping invalid UnifiedPush target from pair payload: {err}");
+                        warn!("Dropping invalid notification target from pair payload: {err}");
                         None
                     } else {
                         Some(target)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -41,8 +41,8 @@ use std::time::Instant;
 
 pub mod auth;
 pub mod fcm;
+pub mod notification_target;
 pub mod security;
-pub mod unifiedpush;
 
 use self::auth::{initialize_users, BasicAuth, FailStore};
 use self::fcm::send_notification;
@@ -140,7 +140,7 @@ async fn persist_pair_notification_target(
 
 async fn load_notification_target(
     root: &Path,
-    unifiedpush_policy: &unifiedpush::UnifiedPushPolicy,
+    notification_target_policy: &notification_target::UnifiedPushPolicy,
 ) -> io::Result<Option<NotificationTarget>> {
     let target_path = root.join("notification_target.json");
     check_path_sandboxed(root, &target_path)?;
@@ -152,7 +152,9 @@ async fn load_notification_target(
     let raw = fs::read_to_string(target_path).await?;
     let parsed = serde_json::from_str::<NotificationTarget>(&raw)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-    if let Err(err) = unifiedpush::validate_notification_target(unifiedpush_policy, &parsed) {
+    if let Err(err) =
+        notification_target::validate_notification_target(notification_target_policy, &parsed)
+    {
         warn!("Ignoring invalid persisted notification target: {err}");
         return Ok(None);
     }
@@ -164,7 +166,7 @@ async fn load_notification_target(
 async fn pair(
     data: Json<PairingRequest>,
     state: &rocket::State<SharedPairingState>,
-    unifiedpush_policy: &rocket::State<unifiedpush::UnifiedPushPolicy>,
+    notification_target_policy: &rocket::State<notification_target::UnifiedPushPolicy>,
     auth: &BasicAuth,
 ) -> Json<PairingResponse> {
     debug!(
@@ -248,8 +250,8 @@ async fn pair(
                 debug!("[PAIR] Phone connected");
                 entry.phone_connected = true;
                 entry.notification_target = data.notification_target.clone().and_then(|target| {
-                    if let Err(err) = unifiedpush::validate_notification_target(
-                        unifiedpush_policy.inner(),
+                    if let Err(err) = notification_target::validate_notification_target(
+                        notification_target_policy.inner(),
                         &target,
                     ) {
                         warn!("Dropping invalid notification target from pair payload: {err}");
@@ -573,11 +575,11 @@ async fn upload_fcm_token(data: Data<'_>, auth: &BasicAuth) -> io::Result<String
 #[post("/notification_target", format = "json", data = "<data>")]
 async fn upload_notification_target(
     data: Json<NotificationTarget>,
-    unifiedpush_policy: &rocket::State<unifiedpush::UnifiedPushPolicy>,
+    notification_target_policy: &rocket::State<notification_target::UnifiedPushPolicy>,
     auth: &BasicAuth,
 ) -> io::Result<String> {
     let target = data.into_inner();
-    unifiedpush::validate_notification_target(unifiedpush_policy.inner(), &target)
+    notification_target::validate_notification_target(notification_target_policy.inner(), &target)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
     let root = Path::new("data").join(&auth.username);
@@ -594,11 +596,11 @@ async fn upload_notification_target(
 
 #[get("/notification_target")]
 async fn retrieve_notification_target(
+    notification_target_policy: &rocket::State<notification_target::UnifiedPushPolicy>,
     auth: &BasicAuth,
-    unifiedpush_policy: &rocket::State<unifiedpush::UnifiedPushPolicy>,
 ) -> Option<Json<NotificationTarget>> {
     let root = Path::new("data").join(&auth.username);
-    let parsed = load_notification_target(&root, unifiedpush_policy.inner())
+    let parsed = load_notification_target(&root, notification_target_policy.inner())
         .await
         .ok()??;
     Some(Json(parsed))
@@ -607,11 +609,12 @@ async fn retrieve_notification_target(
 #[post("/fcm_notification", data = "<data>")]
 async fn send_fcm_notification(
     data: Data<'_>,
+    notification_target_policy: &rocket::State<notification_target::UnifiedPushPolicy>,
     auth: &BasicAuth,
-    unifiedpush_policy: &rocket::State<unifiedpush::UnifiedPushPolicy>,
 ) -> io::Result<String> {
     let root = Path::new("data").join(&auth.username);
-    let notification_target = load_notification_target(&root, unifiedpush_policy.inner()).await?;
+    let notification_target =
+        load_notification_target(&root, notification_target_policy.inner()).await?;
     let notification_msg = data.open(8.kibibytes()).into_bytes().await?;
 
     if let Some(target) = notification_target.as_ref() {
@@ -638,8 +641,8 @@ async fn send_fcm_notification(
                 }
             };
 
-            match unifiedpush::send_notification(
-                unifiedpush_policy.inner(),
+            match notification_target::send_notification(
+                notification_target_policy.inner(),
                 endpoint_url,
                 pub_key,
                 auth_secret,
@@ -1170,8 +1173,8 @@ pub fn build_rocket() -> rocket::Rocket<rocket::Build> {
     } else {
         fcm::fetch_config().expect("Failed to fetch config")
     };
-    let unifiedpush_policy =
-        unifiedpush::UnifiedPushPolicy::from_env().expect("Failed to parse UnifiedPush allowlist");
+    let notification_target_policy = notification_target::UnifiedPushPolicy::from_env()
+        .expect("Failed to parse UnifiedPush allowlist");
 
     rocket::custom(config)
         .attach(ServerVersionHeader {
@@ -1182,7 +1185,7 @@ pub fn build_rocket() -> rocket::Rocket<rocket::Build> {
         .manage(failure_store)
         .manage(pairing_state)
         .manage(fcm_config)
-        .manage(unifiedpush_policy)
+        .manage(notification_target_policy)
         .mount(
             "/",
             routes![

--- a/server/src/notification_target.rs
+++ b/server/src/notification_target.rs
@@ -275,7 +275,7 @@ pub async fn send_notification(
 #[cfg(test)]
 mod tests {
     use super::{validate_notification_target, UnifiedPushPolicy};
-    use secluso_server_backbone::types::NotificationTarget;
+    use secluso_server_backbone::types::{IosRelayBinding, NotificationTarget};
 
     fn android_target(url: &str) -> NotificationTarget {
         NotificationTarget {
@@ -284,6 +284,24 @@ mod tests {
             unifiedpush_endpoint_url: Some(url.to_string()),
             unifiedpush_pub_key: Some("pub".to_string()),
             unifiedpush_auth: Some("auth".to_string()),
+        }
+    }
+
+    // A testing helper to build either the pairing-time placeholder iOS target or a fully bound iOS relay target depending on whether a relay base URL is supplied.
+    fn ios_target(relay_base_url: Option<&str>) -> NotificationTarget {
+        NotificationTarget {
+            platform: "ios".to_string(),
+            ios_relay_binding: relay_base_url.map(|relay_base_url| IosRelayBinding {
+                relay_base_url: relay_base_url.to_string(),
+                hub_token: "hub-token".to_string(),
+                app_install_id: "install-id".to_string(),
+                hub_id: "hub-id".to_string(),
+                device_token: "device-token".to_string(),
+                expires_at_epoch_ms: 1,
+            }),
+            unifiedpush_endpoint_url: None,
+            unifiedpush_pub_key: None,
+            unifiedpush_auth: None,
         }
     }
 
@@ -399,5 +417,25 @@ mod tests {
             &android_target("https://fcm.googleapis.com/fcm/send/example"),
         )
         .unwrap();
+    }
+
+    #[test]
+    // Tests that the pairing-time placeholder target for iOS still passes when no relay binding has been attached yet.
+    fn accepts_ios_placeholder_without_binding() {
+        let policy = UnifiedPushPolicy::with_default_allowlist().unwrap();
+        validate_notification_target(&policy, &ios_target(None))
+            .expect("placeholder iOS target should be accepted without a relay binding");
+    }
+
+    #[test]
+    // Tests that server-side iOS relay checks reject unexpected relay hosts before the target can be persisted to the hub.
+    fn rejects_untrusted_ios_relay_host() {
+        let policy = UnifiedPushPolicy::with_default_allowlist().unwrap();
+        let err = validate_notification_target(&policy, &ios_target(Some("https://evil.example")))
+            .expect_err("unexpected relay host should be rejected");
+
+        assert!(err
+            .to_string()
+            .contains("Refusing unexpected iOS relay host"));
     }
 }

--- a/server/src/notification_target.rs
+++ b/server/src/notification_target.rs
@@ -275,7 +275,7 @@ pub async fn send_notification(
 #[cfg(test)]
 mod tests {
     use super::{validate_notification_target, UnifiedPushPolicy};
-    use secluso_server_backbone::types::{IosRelayBinding, NotificationTarget};
+    use secluso_server_backbone::types::NotificationTarget;
 
     fn android_target(url: &str) -> NotificationTarget {
         NotificationTarget {
@@ -284,23 +284,6 @@ mod tests {
             unifiedpush_endpoint_url: Some(url.to_string()),
             unifiedpush_pub_key: Some("pub".to_string()),
             unifiedpush_auth: Some("auth".to_string()),
-        }
-    }
-
-    fn ios_target(relay_base_url: Option<&str>) -> NotificationTarget {
-        NotificationTarget {
-            platform: "ios".to_string(),
-            ios_relay_binding: relay_base_url.map(|relay_base_url| IosRelayBinding {
-                relay_base_url: relay_base_url.to_string(),
-                hub_token: "hub-token".to_string(),
-                app_install_id: "install-id".to_string(),
-                hub_id: "hub-id".to_string(),
-                device_token: "device-token".to_string(),
-                expires_at_epoch_ms: 1,
-            }),
-            unifiedpush_endpoint_url: None,
-            unifiedpush_pub_key: None,
-            unifiedpush_auth: None,
         }
     }
 

--- a/server/src/security.rs
+++ b/server/src/security.rs
@@ -2,7 +2,33 @@
 
 use std::io;
 use std::io::ErrorKind;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
+
+// The check_path_sandboxed check only we previously had only sees if it stays under the current user's root directory.
+// It still accepts "." because that canonicalizes to the root itself.
+// For route parameters like <camera>, we also need a stricter check.
+// We look for exactly one normal path component so "." / ".." / nested paths cannot traverse within the account root.
+// This protects root-level per-user files like notification_target.json from being treated as if they were inside a camera directory.
+pub(crate) fn validate_path_component(component: &str, label: &str) -> io::Result<()> {
+    let mut components = Path::new(component).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(()),
+        _ => Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("{label} must be a single non-special path component"),
+        )),
+    }
+}
+
+pub(crate) fn join_validated_child(
+    base: &Path,
+    component: &str,
+    label: &str,
+) -> io::Result<PathBuf> {
+    // Validate first so callers never accidentally treat the user root itself as a camera directory by joining "." or another special path.
+    validate_path_component(component, label)?;
+    Ok(base.join(component))
+}
 
 pub(crate) fn check_path_sandboxed(base: &Path, target: &Path) -> io::Result<()> {
     let canonical_base = base.canonicalize()?;
@@ -26,4 +52,42 @@ pub(crate) fn check_path_sandboxed(base: &Path, target: &Path) -> io::Result<()>
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{join_validated_child, validate_path_component};
+    use std::path::Path;
+
+    // This tests to ensure that normal paths work okay.
+    #[test]
+    fn accepts_normal_single_component() {
+        validate_path_component("front-door", "camera").unwrap();
+    }
+
+    // This tests to ensure that "." cannot collapse the camera path back to the user root directory.
+    #[test]
+    fn rejects_current_directory_component() {
+        assert!(validate_path_component(".", "camera").is_err());
+    }
+
+    // This tests to ensure that the attacker cannot escape outside the user root directory
+    #[test]
+    fn rejects_parent_directory_component() {
+        assert!(validate_path_component("..", "camera").is_err());
+    }
+
+    // This tests to ensure the attacker cannot jump over a folder into a sub-folder
+    #[test]
+    fn rejects_nested_component() {
+        assert!(validate_path_component("cam/sub", "camera").is_err());
+    }
+
+    // This tests to ensure the helper both preserves normal child joins and rejects special components like "." before they can collapse back to the user root.
+    #[test]
+    fn join_validated_child_uses_validated_component() {
+        let joined = join_validated_child(Path::new("/tmp/base"), "cam1", "camera").unwrap();
+        assert_eq!(joined, Path::new("/tmp/base").join("cam1"));
+        assert!(join_validated_child(Path::new("/tmp/base"), ".", "camera").is_err());
+    }
 }

--- a/server/src/unifiedpush.rs
+++ b/server/src/unifiedpush.rs
@@ -1,10 +1,10 @@
-//! UnifiedPush / Web Push delivery helpers.
+//! Notification target delivery and allowlist helpers.
 //!
 //! SPDX-License-Identifier: GPL-3.0-or-later
 
 use anyhow::{Context, Result};
 use reqwest::Url;
-use secluso_server_backbone::types::NotificationTarget;
+use secluso_server_backbone::types::{IosRelayBinding, NotificationTarget};
 use std::env;
 use web_push::{
     ContentEncoding, IsahcWebPushClient, SubscriptionInfo, WebPushClient, WebPushMessageBuilder,
@@ -22,6 +22,9 @@ const DEFAULT_ALLOWED_HOSTS: &[&str] = &[
     "up.conversations.im",
     "fcm.googleapis.com",
 ];
+
+// The public Secluso iOS relay and the review/testing relay are the only trusted iOS relays
+const DEFAULT_IOS_RELAY_HOSTS: &[&str] = &["relay.secluso.com", "testing-relay.secluso.com"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AllowedEndpoint {
@@ -42,6 +45,7 @@ impl UnifiedPushPolicy {
         Ok(policy)
     }
 
+    #[cfg(test)]
     fn from_allowlist_csv(raw: &str) -> Result<Self> {
         let mut policy = Self::default();
         policy.extend_from_allowlist_csv(raw)?;
@@ -139,10 +143,83 @@ fn parse_allowed_endpoint(raw: &str) -> Result<AllowedEndpoint> {
     })
 }
 
+/// Validate the configured iOS relay base URL before the server stores or re-serves it back to a hub.
+/// The hub treats this URL as an outbound notification destination, so we enforce HTTPS only, no credentials, no query/fragment/path prefix, and one of the built-in relay hosts.
+fn validate_ios_relay_base_url(raw_url: &str) -> Result<Url> {
+    let parsed =
+        Url::parse(raw_url).with_context(|| format!("Invalid iOS relay base URL: {raw_url}"))?;
+    if parsed.scheme() != "https" {
+        anyhow::bail!("Refusing non-HTTPS iOS relay base URL: {raw_url}");
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        anyhow::bail!("iOS relay base URL must not include credentials: {raw_url}");
+    }
+    if parsed.query().is_some() {
+        anyhow::bail!("iOS relay base URL must not include a query: {raw_url}");
+    }
+    if parsed.fragment().is_some() {
+        anyhow::bail!("iOS relay base URL must not include a fragment: {raw_url}");
+    }
+    if parsed.path() != "/" {
+        anyhow::bail!("iOS relay base URL must not include a path prefix: {raw_url}");
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| anyhow::anyhow!("iOS relay base URL is missing a host: {raw_url}"))?;
+    let port = parsed
+        .port_or_known_default()
+        .ok_or_else(|| anyhow::anyhow!("iOS relay base URL is missing an HTTPS port: {raw_url}"))?;
+    if port != 443 {
+        anyhow::bail!("iOS relay base URL must use the default HTTPS port: {raw_url}");
+    }
+    if !DEFAULT_IOS_RELAY_HOSTS
+        .iter()
+        .any(|allowed| host.eq_ignore_ascii_case(allowed))
+    {
+        anyhow::bail!("Refusing unexpected iOS relay host {host}");
+    }
+
+    Ok(parsed)
+}
+
+/// Validate that an iOS relay binding is complete enough to be usable and that its relay base URL still points at a trusted relay.
+fn validate_ios_binding(binding: &IosRelayBinding) -> Result<()> {
+    let relay_base = binding.relay_base_url.trim();
+    if relay_base.is_empty() {
+        anyhow::bail!("iOS relay base URL is required.");
+    }
+    validate_ios_relay_base_url(relay_base)?;
+
+    if binding.hub_token.trim().is_empty()
+        || binding.app_install_id.trim().is_empty()
+        || binding.hub_id.trim().is_empty()
+        || binding.device_token.trim().is_empty()
+    {
+        anyhow::bail!("iOS relay binding is incomplete.");
+    }
+    if binding.expires_at_epoch_ms == 0 {
+        anyhow::bail!("iOS relay binding must include a non-zero expiration.");
+    }
+
+    Ok(())
+}
+
+/// Validate notification delivery metadata before persisting it or handing it back to the hub.
+/// iOS targets are allowed to appear without a relay binding during the placeholder stage of pairing, but any supplied relay binding must still pass the trusted-relay checks above.
 pub fn validate_notification_target(
-    policy: &UnifiedPushPolicy,
+    unifiedpush_policy: &UnifiedPushPolicy,
     target: &NotificationTarget,
 ) -> Result<()> {
+    // Defer ios to the validate_ios_binding method
+    if target.platform.eq_ignore_ascii_case("ios") {
+        if let Some(binding) = target.ios_relay_binding.as_ref() {
+            validate_ios_binding(binding)?;
+        }
+        return Ok(());
+    }
+
+    // If it doesn't match ios or android_unified, it doesn't belong here.
     if !target.platform.eq_ignore_ascii_case("android_unified") {
         return Ok(());
     }
@@ -166,7 +243,7 @@ pub fn validate_notification_target(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| anyhow::anyhow!("UnifiedPush auth secret is required."))?;
 
-    policy.validate_endpoint_url(endpoint_url)?;
+    unifiedpush_policy.validate_endpoint_url(endpoint_url)?;
 
     if pub_key.is_empty() || auth.is_empty() {
         anyhow::bail!("UnifiedPush key material is incomplete.");
@@ -198,7 +275,7 @@ pub async fn send_notification(
 #[cfg(test)]
 mod tests {
     use super::{validate_notification_target, UnifiedPushPolicy};
-    use secluso_server_backbone::types::NotificationTarget;
+    use secluso_server_backbone::types::{IosRelayBinding, NotificationTarget};
 
     fn android_target(url: &str) -> NotificationTarget {
         NotificationTarget {
@@ -207,6 +284,23 @@ mod tests {
             unifiedpush_endpoint_url: Some(url.to_string()),
             unifiedpush_pub_key: Some("pub".to_string()),
             unifiedpush_auth: Some("auth".to_string()),
+        }
+    }
+
+    fn ios_target(relay_base_url: Option<&str>) -> NotificationTarget {
+        NotificationTarget {
+            platform: "ios".to_string(),
+            ios_relay_binding: relay_base_url.map(|relay_base_url| IosRelayBinding {
+                relay_base_url: relay_base_url.to_string(),
+                hub_token: "hub-token".to_string(),
+                app_install_id: "install-id".to_string(),
+                hub_id: "hub-id".to_string(),
+                device_token: "device-token".to_string(),
+                expires_at_epoch_ms: 1,
+            }),
+            unifiedpush_endpoint_url: None,
+            unifiedpush_pub_key: None,
+            unifiedpush_auth: None,
         }
     }
 


### PR DESCRIPTION
This PR hardens the notification target flow against SSRF and path-traversal issues in the server, camera_hub, and client_lib. 

On the server side, it validates camera path components so camera routes cannot collapse back to the user root (e.g. via .), and it validates iOS relay targets before accepting / persisting / re-serving them. 

On the client side, camera_hub now re-validates iOS relay bindings before any outbound send. 