### PR TITLE
Limit persmissions of github workflows.

### DIFF
--- a/.github/workflows/client-lib-tests.yml
+++ b/.github/workflows/client-lib-tests.yml
@@ -14,6 +14,9 @@ on:
       - 'client_lib/**'
       - '.github/workflows/client-lib-tests.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test-client-lib:
     runs-on: ubuntu-latest

--- a/.github/workflows/example-app-test.yml
+++ b/.github/workflows/example-app-test.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   example-app-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Content read permission is enough for these workflows to successfully execute.