### PR TITLE
Check the latest GitHub release and use local hints for updating the components

### DIFF
--- a/client_lib/src/http_client.rs
+++ b/client_lib/src/http_client.rs
@@ -6,12 +6,14 @@ use base64::engine::general_purpose::STANDARD as base64_engine;
 use base64::{engine::general_purpose, Engine as _};
 use reqwest::blocking::{Body, Client, RequestBuilder};
 use reqwest::Url;
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, BufWriter, Write, Read};
 use std::path::Path;
 use std::time::Duration;
+use std::env;
 
 // Some of these constants are based on the ones in server/main.rs.
 const MAX_MOTION_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50 mebibytes
@@ -159,6 +161,19 @@ impl HttpClient {
         }
     }
 
+    fn give_hint_to_updater() {
+        if let Ok(update_hint_path_str) = env::var("UPDATE_HINT_PATH") {
+            let update_hint_path = Path::new(&update_hint_path_str);
+
+            if !update_hint_path.exists() {
+                if let Err(e) = File::create(update_hint_path) {
+                    eprintln!("Failed to create file: {}", e);
+                }
+                println!("Update hint file created: {}", update_hint_path_str);
+            }
+        }
+    }
+
     /// Atomically confirm pairing with app and receive any phone-side notification target metadata.
     pub fn send_pairing_token(&self, pairing_token: &str) -> io::Result<PairingStatus> {
         let url = format!("{}/pair", self.server_addr);
@@ -179,6 +194,10 @@ impl HttpClient {
             .body(body.to_string())
             .send()
             .map_err(|e| io::Error::new(io::ErrorKind::TimedOut, e.to_string()))?;
+
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
 
         if !response.status().is_success() {
             return Err(io::Error::new(
@@ -209,7 +228,11 @@ impl HttpClient {
             .send()
             .map_err(|e| io::Error::new(io::ErrorKind::TimedOut, e.to_string()))?;
 
-        if response.status() == reqwest::StatusCode::NOT_FOUND {
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
+
+        if response.status() == StatusCode::NOT_FOUND {
             return Ok(None);
         }
 
@@ -276,6 +299,10 @@ impl HttpClient {
             .body(payload.to_string())
             .send()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
 
         if !response.status().is_success() {
             let status = response.status();
@@ -358,6 +385,10 @@ impl HttpClient {
             .send()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
+
         if !response.status().is_success() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -402,9 +433,11 @@ impl HttpClient {
         let response = self.authorized_headers(client
             .get(&server_url))
             .send()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
-            .error_for_status()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
 
         if !response.status().is_success() {
             return Err(io::Error::new(
@@ -431,9 +464,11 @@ impl HttpClient {
         let del_response = self.authorized_headers(client
             .delete(&server_url))
             .send()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
-            .error_for_status()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if del_response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
 
         if !del_response.status().is_success() {
             return Err(io::Error::new(
@@ -452,9 +487,11 @@ impl HttpClient {
         let response = self.authorized_headers(client
             .delete(&server_url))
             .send()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
-            .error_for_status()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
 
         if !response.status().is_success() {
             return Err(io::Error::new(
@@ -477,6 +514,10 @@ impl HttpClient {
             .send()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
+
         if !response.status().is_success() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -497,6 +538,10 @@ impl HttpClient {
             .header("Content-Type", "application/octet-stream")
             .send()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
 
         if !response.status().is_success() {
             return Err(io::Error::new(
@@ -522,9 +567,18 @@ impl HttpClient {
         let response = self.authorized_headers(client
             .get(&server_url))
             .send()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
-            .error_for_status()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
+
+        if !response.status().is_success() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Server error: {}", response.status()),
+            ));
+        }
 
         let mut buf = Vec::new();
         let mut limited = response.take(max_size);
@@ -576,6 +630,10 @@ impl HttpClient {
             .send()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
+
         if !response.status().is_success() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -615,9 +673,11 @@ impl HttpClient {
         let response = self.authorized_headers(client
             .get(&server_url))
             .send()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
-            .error_for_status()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
 
         if !response.status().is_success() {
             return Err(io::Error::new(
@@ -638,9 +698,11 @@ impl HttpClient {
         let del_response = self.authorized_headers(client
             .delete(&server_del_url))
             .send()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
-            .error_for_status()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if del_response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
 
         if !del_response.status().is_success() {
             return Err(io::Error::new(
@@ -664,6 +726,10 @@ impl HttpClient {
             .send()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
+
         if !response.status().is_success() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -685,6 +751,10 @@ impl HttpClient {
             .body(command)
             .send()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
 
         if !response.status().is_success() {
             return Err(io::Error::new(
@@ -712,9 +782,18 @@ impl HttpClient {
         let response = self.authorized_headers(client
             .get(&server_url))
             .send()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
-            .error_for_status()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
+
+        if !response.status().is_success() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Server error: {}", response.status()),
+            ));
+        }
 
         let mut buf = Vec::new();
         let mut limited = response.take(max_size);
@@ -757,6 +836,10 @@ impl HttpClient {
             .send()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
+
         if !response.status().is_success() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -784,9 +867,11 @@ impl HttpClient {
         let response = self.authorized_headers(client
             .get(&server_url))
             .send()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
-            .error_for_status()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        if response.status() == StatusCode::CONFLICT {
+            Self::give_hint_to_updater();
+        }
 
         if !response.status().is_success() {
             return Err(io::Error::new(

--- a/deploy/src-tauri/assets/pi_hub/build_image.sh
+++ b/deploy/src-tauri/assets/pi_hub/build_image.sh
@@ -385,6 +385,7 @@ ExecStartPre=/usr/bin/test -r /var/lib/secluso/wifi_password
 ExecStart=${SECLUSO_INSTALL_DIR}/bin/secluso-raspberry-camera-hub
 Environment="RUST_LOG=info"
 Environment="LD_LIBRARY_PATH=/usr/local/lib/aarch64-linux-gnu/:/usr/local/lib:${LD_LIBRARY_PATH:-}"
+Environment="UPDATE_HINT_PATH=/var/lib/secluso/update_hint"
 Restart=always
 RestartSec=1
 
@@ -414,6 +415,8 @@ EOF
 
   if [[ -x "$ROOT${SECLUSO_INSTALL_DIR}/bin/$updater_name" ]]; then
     UPDATE_INTERVAL_SECS="1800"
+    HINT_CHECK_INTERVAL_SECS="60"
+    UPDATE_HINT_PATH="/var/lib/secluso/update_hint"
     cat > "$ROOT/etc/systemd/system/secluso-updater.service" <<EOF
 [Unit]
 Description=Secluso Updater
@@ -422,7 +425,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=${SECLUSO_INSTALL_DIR}/bin/${updater_name} --component raspberry_camera_hub --interval-secs ${UPDATE_INTERVAL_SECS} --github-timeout-secs 20 --restart-unit secluso_camera_hub.service --github-repo ${SECLUSO_REPO}${SIG_ARGS}
+ExecStart=${SECLUSO_INSTALL_DIR}/bin/${updater_name} --component raspberry_camera_hub --interval-secs ${UPDATE_INTERVAL_SECS} --github-timeout-secs 20 --restart-unit secluso_camera_hub.service --github-repo ${SECLUSO_REPO}${SIG_ARGS} --update-hint-path ${UPDATE_HINT_PATH} --hint-check-interval-secs ${HINT_CHECK_INTERVAL_SECS}
 Restart=always
 RestartSec=2
 

--- a/deploy/src-tauri/assets/server/provision_server.sh
+++ b/deploy/src-tauri/assets/server/provision_server.sh
@@ -29,6 +29,7 @@ STATE_DIR="${STATE_DIR:-/var/lib/secluso}"
 SERVICE_USER="${SERVICE_USER:-secluso}"
 RELEASE_TAG="${RELEASE_TAG:-unknown}"
 UPDATE_INTERVAL_SECS="${UPDATE_INTERVAL_SECS:-1800}"
+HINT_CHECK_INTERVAL_SECS="${HINT_CHECK_INTERVAL_SECS:-60}"
 STAGING_DIR="${STAGING_DIR:-}"
 SIG_ARGS=""
 if [[ -n "${SIG_KEYS:-}" ]]; then
@@ -133,6 +134,7 @@ Restart=always
 RestartSec=1
 Environment=RUST_LOG=info
 Environment=SECLUSO_USER_CREDENTIALS_DIR=$STATE_DIR/user_credentials
+Environment=UPDATE_HINT_PATH=$STATE_DIR/update_hint
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=true
@@ -152,7 +154,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=$INSTALL_PREFIX/bin/secluso-update --component server --interval-secs $UPDATE_INTERVAL_SECS --github-timeout-secs 20 --restart-unit $SERVER_UNIT --github-repo $OWNER_REPO$SIG_ARGS
+ExecStart=$INSTALL_PREFIX/bin/secluso-update --component server --interval-secs $UPDATE_INTERVAL_SECS --github-timeout-secs 20 --restart-unit $SERVER_UNIT --github-repo $OWNER_REPO$SIG_ARGS --update-hint-path $STATE_DIR/update_hint --hint-check-interval-secs $HINT_CHECK_INTERVAL_SECS
 Restart=always
 RestartSec=2
 ${GITHUB_TOKEN:+Environment=GITHUB_TOKEN=$GITHUB_TOKEN}

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::ffi::OsString;
 use std::fs;
+use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::str;
@@ -21,6 +22,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
+use std::env;
 use subtle::{Choice, ConstantTimeEq};
 
 const DUMMY_PASSWORD: [u8; NUM_PASSWORD_CHARS] = [0u8; NUM_PASSWORD_CHARS];
@@ -103,6 +105,20 @@ fn to_fixed_bytes(s: &str) -> [u8; NUM_PASSWORD_CHARS] {
     out
 }
 
+fn give_hint_to_updater() {
+    if let Ok(update_hint_path_str) = env::var("UPDATE_HINT_PATH") {
+        let update_hint_path = Path::new(&update_hint_path_str);
+
+        if !update_hint_path.exists() {
+            if let Err(e) = File::create(update_hint_path) {
+                eprintln!("Failed to create file: {}", e);
+            }
+            println!("Update hint file created: {}", update_hint_path_str);
+        }
+    }
+}
+
+
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for &'r BasicAuth {
     type Error = ();
@@ -128,9 +144,13 @@ impl<'r> FromRequest<'r> for &'r BasicAuth {
         // We run a check on client-provided version header to ensure a match.
         // If it fails, we return a 409 (Conflict).
         // It must be provided for all, or we cannot guarantee version-compatibility.
+        // When there's a version mismatch, we also give a hint to the updater so
+        // that it can check the Github latest release. The version mismatch might
+        // be because the server is running an old version.
         if let Some(client_version) = client_header {
             let version = env!("CARGO_PKG_VERSION");
             if client_version != version {
+                give_hint_to_updater();
                 return Outcome::Error((Status::Conflict, ()));
             }
         } else {

--- a/update/src/lib.rs
+++ b/update/src/lib.rs
@@ -116,16 +116,6 @@ struct Artifact {
     sha256: String,
 }
 
-#[derive(Debug, Deserialize)]
-struct StoredUserCredentials {
-    #[serde(rename = "u", alias = "username")]
-    username: String,
-    #[serde(rename = "p", alias = "password")]
-    password: String,
-    #[serde(rename = "sa", alias = "server_addr")]
-    server_addr: String,
-}
-
 #[derive(Debug, Clone)]
 pub struct VerifiedComponent {
     pub release_tag: String,
@@ -134,63 +124,6 @@ pub struct VerifiedComponent {
     pub component_path: String,
     pub component_bytes: Vec<u8>,
     pub bundle_bytes: Vec<u8>,
-}
-
-pub fn server_version(client_version: &str) -> Result<Option<String>> {
-    let file_path = format!("{}/{}", WORKING_DIRECTORY, "credentials_full");
-    server_version_from_path(Path::new(&file_path), client_version)
-}
-
-fn parse_credentials_full(contents: &str) -> Result<Option<(String, String, String)>> {
-    if contents.trim().is_empty() {
-        return Ok(None);
-    }
-
-    if let Ok(parsed) = serde_json::from_str::<StoredUserCredentials>(contents) {
-        return Ok(Some((parsed.username, parsed.password, parsed.server_addr)));
-    }
-
-    if contents.len() <= NUM_USERNAME_CHARS + NUM_PASSWORD_CHARS {
-        return Ok(None);
-    }
-
-    Ok(Some((
-        contents[0..NUM_USERNAME_CHARS].to_string(),
-        contents[NUM_USERNAME_CHARS..NUM_USERNAME_CHARS + NUM_PASSWORD_CHARS].to_string(),
-        contents[NUM_USERNAME_CHARS + NUM_PASSWORD_CHARS..].to_string(),
-    )))
-}
-
-fn server_version_from_path(file_path: &Path, client_version: &str) -> Result<Option<String>> {
-    let credentials_exist = fs::exists(file_path)?;
-    if !credentials_exist {
-        return Ok(None);
-    }
-
-    let user_credentials_contents = fs::read_to_string(file_path)?;
-    let Some((server_username, server_password, server_addr)) =
-        parse_credentials_full(&user_credentials_contents)?
-    else {
-        return Ok(None);
-    };
-
-    let response = reqwest::blocking::Client::new()
-        .get(format!("{}/status", server_addr.trim_end_matches('/')))
-        .header("Client-Version", client_version)
-        .basic_auth(server_username, Some(server_password))
-        .send()?;
-
-    if !(response.status().is_success() || response.status() == reqwest::StatusCode::CONFLICT) {
-        return Ok(None);
-    }
-
-    if let Some(server_version) = response.headers().get("X-Server-Version") {
-        if let Ok(version_str) = server_version.to_str() {
-            return Ok(Some(version_str.to_string()));
-        }
-    }
-
-    Ok(None)
 }
 
 impl Component {
@@ -333,22 +266,6 @@ pub fn build_github_client(
         .default_headers(headers)
         .build()
         .context("building GitHub HTTP client")
-}
-
-// Fetches a specific release from GitHub's API endpoint for the target repo.
-// Callers are expected to apply additional policy checks (draft/published/immutable) before trusting
-// the returned release for installation decisions.
-pub fn fetch_versioned_release(
-    client: &Client,
-    owner_repo: &str,
-    tag_name: &str,
-) -> Result<GhRelease> {
-    let url = format!(
-        "https://api.github.com/repos/{}/releases/tags/{}",
-        owner_repo, tag_name
-    );
-    let resp = client.get(&url).send()?.error_for_status()?;
-    Ok(resp.json::<GhRelease>()?)
 }
 
 // Fetches the latest release metadata from GitHub's API endpoint for the target repo.

--- a/update/src/main.rs
+++ b/update/src/main.rs
@@ -10,12 +10,12 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::sleep;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH, Instant};
 
 use secluso_update::{
     build_github_client, default_signers, download_and_verify_component, fetch_latest_release,
-    fetch_versioned_release, get_current_version, github_token_from_env, parse_sig_keys,
-    require_release_is_immutable, server_version, write_current_version, Component,
+    get_current_version, github_token_from_env, parse_sig_keys,
+    require_release_is_immutable, write_current_version, Component,
     DEFAULT_OWNER_REPO,
 };
 
@@ -23,23 +23,25 @@ const USAGE: &str = r#"
 Secluso updater.
 
 Usage:
-  secluso-update --component COMPONENT [--once] [--bundle-path PATH] [--interval-secs N] [--github-timeout-secs N] [--restart-unit UNIT] [--github-repo <OWNER/REPO>] [--sig-key <NAME:GITHUB_USER>]...
+  secluso-update --component COMPONENT [--once] [--bundle-path PATH] [--interval-secs N] [--github-timeout-secs N] [--restart-unit UNIT] [--github-repo <OWNER/REPO>] [--sig-key <NAME:GITHUB_USER>]... [--update-hint-path PATH] [--hint-check-interval-secs N]
   secluso-update (--help | -h)
   secluso-update (--version | -v)
 
 Options:
-  --component COMPONENT      Which single binary to update:
-                             server | updater | raspberry_camera_hub | config_tool
-  --restart-unit UNIT        systemd unit to restart after install (optional).
-                             If omitted, no service is restarted.
-  --interval-secs N          Poll interval seconds [default: 60].
-  --github-timeout-secs N    HTTP timeout seconds [default: 20].
-  --github-repo <OWNER/REPO>  GitHub repo to poll for releases [default: secluso/secluso].
+  --component COMPONENT         Which single binary to update:
+                                server | updater | raspberry_camera_hub | config_tool
+  --restart-unit UNIT           systemd unit to restart after install (optional).
+                                If omitted, no service is restarted.
+  --interval-secs N             Poll interval seconds [default: 60].
+  --github-timeout-secs N       HTTP timeout seconds [default: 20].
+  --github-repo <OWNER/REPO>    GitHub repo to poll for releases [default: secluso/secluso].
   --sig-key <NAME:GITHUB_USER>  Signature label + GitHub user (repeatable).
-  --once                     Run a single update check then exit.
-  --bundle-path PATH         Use a local bundle zip instead of downloading from GitHub.
-  --version, -v              Show tool version.
-  --help, -h                 Show this screen.
+  --once                        Run a single update check then exit.
+  --bundle-path PATH            Use a local bundle zip instead of downloading from GitHub.
+  --update-hint-path PATH       Path for the local update hint file (optional).
+  --hint-check-interval-secs N  Update hint poll interval seconds [default: 10].
+  --version, -v                 Show tool version.
+  --help, -h                    Show this screen.
 "#;
 
 #[derive(Debug, Deserialize)]
@@ -52,12 +54,13 @@ struct Args {
     flag_sig_key: Vec<String>,
     flag_once: bool,
     flag_bundle_path: Option<String>,
+    flag_update_hint_path: Option<String>,
+    flag_hint_check_interval_secs: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReleaseSource {
     LatestImmutableGitHub,
-    ServerCoordinated,
 }
 
 #[derive(Debug, Clone)]
@@ -128,12 +131,59 @@ fn main() -> ! {
         std::process::exit(0);
     }
 
-    loop {
-        println!("Going to check for updates.");
-        if let Err(e) = check_update(&args) {
-            eprintln!("Update check failed: {:#}", e);
+    if let Some(ref update_hint_path) = args.flag_update_hint_path {
+        if args.flag_interval_secs % args.flag_hint_check_interval_secs != 0 {
+            eprintln!(
+                "flag_interval_secs ({}) must be divisible by flag_update_hint_interval_secs ({})",
+                args.flag_interval_secs,
+                args.flag_hint_check_interval_secs
+            );
+            std::process::exit(1);
         }
-        sleep(Duration::from_secs(args.flag_interval_secs));
+
+        // We want to force a check in the beginning.
+        let mut last_full_check = Instant::now() - Duration::from_secs(args.flag_interval_secs);
+
+        loop {
+            let elapsed = last_full_check.elapsed();
+            if elapsed >= Duration::from_secs(args.flag_interval_secs) {
+                println!("Scheduled update check.");
+                if let Err(e) = check_update(&args) {
+                    eprintln!("Update check failed: {:#}", e);
+                }
+                last_full_check = Instant::now();
+                continue;
+            }
+
+            sleep(Duration::from_secs(args.flag_hint_check_interval_secs));
+
+            if is_there_update_hint(&update_hint_path) {
+                println!("Update hint received, triggering early check.");
+                if let Err(e) = check_update(&args) {
+                    eprintln!("Update check failed: {:#}", e);
+                }
+                last_full_check = Instant::now();
+            }
+        }
+    } else {
+        loop {
+            println!("Going to check for updates.");
+            if let Err(e) = check_update(&args) {
+                eprintln!("Update check failed: {:#}", e);
+            }
+            sleep(Duration::from_secs(args.flag_interval_secs));
+        }
+    }
+}
+
+pub fn is_there_update_hint(path: &str) -> bool {
+    let p = Path::new(path);
+
+    if p.exists() {
+        let _ = fs::remove_file(p);
+        true
+    } else {
+        false
     }
 }
 
@@ -171,8 +221,6 @@ fn check_update(args: &Args) -> Result<()> {
         &current_version,
         || fetch_latest_release(&client, &github_repo),
         require_release_is_immutable,
-        |client_version| server_version(client_version),
-        |version| fetch_versioned_release(&client, &github_repo, version),
     )?
     else {
         return Ok(());
@@ -181,9 +229,6 @@ fn check_update(args: &Args) -> Result<()> {
     match selected_release.source {
         ReleaseSource::LatestImmutableGitHub => {
             println!("Using the latest immutable GitHub release.");
-        }
-        ReleaseSource::ServerCoordinated => {
-            println!("Using the server-coordinated release.");
         }
     };
 
@@ -340,22 +385,18 @@ fn create_secure_install_temp_file(
     ))
 }
 
-fn select_release_for_component<FLatest, FRequireImmutable, FServerVersion, FFetchVersioned>(
+fn select_release_for_component<FLatest, FRequireImmutable>(
     component: Component,
     current_version: &Version,
     fetch_latest_release_fn: FLatest,
     require_release_is_immutable_fn: FRequireImmutable,
-    server_version_fn: FServerVersion,
-    fetch_versioned_release_fn: FFetchVersioned,
 ) -> Result<Option<SelectedRelease>>
 where
     FLatest: FnOnce() -> Result<secluso_update::GhRelease>,
     FRequireImmutable: FnOnce(&secluso_update::GhRelease) -> Result<()>,
-    FServerVersion: FnOnce(&str) -> Result<Option<String>>,
-    FFetchVersioned: FnOnce(&str) -> Result<secluso_update::GhRelease>,
 {
     match component {
-        Component::Server => {
+        _ => {
             let release = fetch_latest_release_fn()?;
             require_release_is_immutable_fn(&release)?;
 
@@ -368,24 +409,6 @@ where
             Ok(Some(SelectedRelease {
                 release,
                 source: ReleaseSource::LatestImmutableGitHub,
-            }))
-        }
-        Component::Updater | Component::RaspberryCameraHub | Component::ConfigTool => {
-            let Some(server_version) = server_version_fn(&current_version.to_string())? else {
-                println!("Server version unavailable; update not needed yet");
-                return Ok(None);
-            };
-
-            let latest_version = Version::parse(server_version.trim_start_matches('v'))?;
-            if current_version >= &latest_version {
-                println!("Already on the server-coordinated release.");
-                return Ok(None);
-            }
-
-            let release = fetch_versioned_release_fn(&server_version)?;
-            Ok(Some(SelectedRelease {
-                release,
-                source: ReleaseSource::ServerCoordinated,
             }))
         }
     }


### PR DESCRIPTION
Previously, non-server components such as the camera_hub checked the server version in order to determine when to update. That allows a malicious server to keep these components outdated. Instead, we will now have all the components check the latest GitHub release to decide if they should update or not.

These checks, however, are not frequent, e.g., every 30 minutes in the image we build with our deploy tool. This could create a large downtime for the camera as there can be version mismatch with the server for up to 30 minutes every time we update the server. To address this, when the client_lib http code (used in the camera_hub) sees a version mismatch with the server, it provides a hint to the updater. The updater checks for the hint more frequently, e.g., every minute. If it sees a hint, it checks the latest GitHub release and updates if needed.

This PR also updates the deploy tool accordingly.