### PR TITLE
Harden artifact verification and signer trust across the pipeline

### DIFF
--- a/deploy/src-tauri/Cargo.lock
+++ b/deploy/src-tauri/Cargo.lock
@@ -96,56 +96,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,12 +861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,29 +1557,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -2930,12 +2851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,30 +2886,6 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3697,18 +3588,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -4062,12 +3941,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -4699,21 +4572,6 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
-dependencies = [
- "portable-atomic",
 ]
 
 [[package]]
@@ -5609,11 +5467,8 @@ dependencies = [
  "anyhow",
  "base64-url",
  "bincode",
- "docopt",
- "env_logger",
  "image",
  "log",
- "mio 0.8.11",
  "openmls",
  "openmls_basic_credential",
  "openmls_libcrux_crypto",
@@ -6880,7 +6735,7 @@ checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -7294,12 +7149,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -7847,15 +7696,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7903,21 +7743,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7979,12 +7804,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -8003,12 +7822,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -8024,12 +7837,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8063,12 +7870,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8084,12 +7885,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8111,12 +7906,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -8132,12 +7921,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/deploy/src-tauri/assets/pi_hub/Dockerfile
+++ b/deploy/src-tauri/assets/pi_hub/Dockerfile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-FROM debian:bookworm
+FROM docker.io/debian@sha256:1d6cd964917a13b547d1ea392dff9a000c3f36070686ebc5c8755d53fb374435
 
 RUN set -eux; \
     apt-get update; \

--- a/deploy/src-tauri/assets/pi_hub/build_image.sh
+++ b/deploy/src-tauri/assets/pi_hub/build_image.sh
@@ -451,7 +451,7 @@ install_rpicam_apps() {
   install_pinned_libcamera() {
   local ver="0.4.0+rpt20250213-1"
   local arch="arm64"
-  local base="https://mirror.fsmg.org.nz/pub/raspberrypi/debian/pool/main/libc/libcamera"
+  local base="https://archive.raspberrypi.com/debian/pool/main/libc/libcamera"
 
   echo "+ Pinning libcamera stack to $ver" >&2
 

--- a/deploy/src-tauri/assets/pi_hub/build_image.sh
+++ b/deploy/src-tauri/assets/pi_hub/build_image.sh
@@ -369,7 +369,7 @@ if [[ "$HAS_SECLUSO" == "true" ]]; then
   if jq -e '.secluso.sig_keys | length > 0' "$CFG" >/dev/null 2>&1; then
     while read -r key; do
       SIG_ARGS="$SIG_ARGS --sig-key $key"
-    done < <(jq -r '.secluso.sig_keys[] | "\(.name):\(.github_user)"' "$CFG")
+    done < <(jq -r '.secluso.sig_keys[] | if (.fingerprint // "") != "" then "\(.name):\(.github_user):\(.fingerprint)" else "\(.name):\(.github_user)" end' "$CFG")
   fi
 
   run chroot "$ROOT" bash -lc "cd '${SECLUSO_INSTALL_DIR}/bin' && './${updater_name}' --help 2>/dev/null | grep -q -- '--component' || exit 1"

--- a/deploy/src-tauri/assets/pi_hub/build_image.sh
+++ b/deploy/src-tauri/assets/pi_hub/build_image.sh
@@ -15,6 +15,20 @@ emit() {
   printf '::SECLUSO_EVENT::{"level":"%s","step":"%s","msg":"%s"}\n' "$level" "$step" "$msg"
 }
 
+verify_sha256() {
+  local path="$1"
+  local expected_sha="$2"
+  local actual_sha
+
+  actual_sha="$(sha256sum "$path" | awk '{print $1}')"
+  [ "$actual_sha" = "$expected_sha" ] || {
+    echo "SHA-256 mismatch for $path" >&2
+    echo "  expected: $expected_sha" >&2
+    echo "  actual:   $actual_sha" >&2
+    exit 1
+  }
+}
+
 ensure_loop_devices() {
   # Fixes case where the host already had many loop devices 
   # in use (for example snap mounts), and a failed run could also leave stale mappings behind. This helper makes
@@ -82,10 +96,12 @@ emit "info" "base_image" "Preparing base image..."
 
 # fetch base image
 if [[ "$BASE_IMAGE" == http://* || "$BASE_IMAGE" == https://* ]]; then
+  base_image_sha256="6ac3a10a1f144c7e9d1f8e568d75ca809288280a593eb6ca053e49b539f465a4"
   fname="$(basename "$BASE_IMAGE")"
   if [[ ! -f "$fname" ]]; then
     run curl -L -o "$fname" "$BASE_IMAGE"
   fi
+  verify_sha256 "$fname" "$base_image_sha256"
   BASE_PATH="$WORK/$fname"
 else
   if [[ -f "$BASE_IMAGE" ]]; then BASE_PATH="$BASE_IMAGE"
@@ -452,6 +468,11 @@ install_rpicam_apps() {
   local ver="0.4.0+rpt20250213-1"
   local arch="arm64"
   local base="https://archive.raspberrypi.com/debian/pool/main/libc/libcamera"
+  local libcamera0_4_sha256="c505ae5c3311c82b8cd8257da4288aacb50717e394a494c205f89fdc9385f72b"
+  local libcamera_ipa_sha256="ff88b7089155f85fb939a0588cc2df859fa119847d7e7b8fbab33790063b6622"
+  local libcamera_dev_sha256="defeb14a390df0bb806e1c4cce4329a761d4e7ede9c31ba979e6662f0a8fdb07"
+  local libcamera_tools_sha256="aa7dacdc7b71d2a6da8566c13adb12133925304da40bba938553eb8b33d9617d"
+  local python3_libcamera_sha256="f17ab305580a2efa81246b7b2035f1c7ca9a790e9d0abed9d097b005a9077f40"
 
   echo "+ Pinning libcamera stack to $ver" >&2
 
@@ -483,6 +504,11 @@ EOF"
     curl -fsSL -O '$base/libcamera-dev_${ver}_${arch}.deb';
     curl -fsSL -O '$base/libcamera-tools_${ver}_${arch}.deb' || true;
     curl -fsSL -O '$base/python3-libcamera_${ver}_${arch}.deb' || true;
+    echo '$libcamera0_4_sha256  /tmp/libcamera0.4_${ver}_${arch}.deb' | sha256sum -c -;
+    echo '$libcamera_ipa_sha256  /tmp/libcamera-ipa_${ver}_${arch}.deb' | sha256sum -c -;
+    echo '$libcamera_dev_sha256  /tmp/libcamera-dev_${ver}_${arch}.deb' | sha256sum -c -;
+    if [ -f /tmp/libcamera-tools_${ver}_${arch}.deb ]; then echo '$libcamera_tools_sha256  /tmp/libcamera-tools_${ver}_${arch}.deb' | sha256sum -c -; fi;
+    if [ -f /tmp/python3-libcamera_${ver}_${arch}.deb ]; then echo '$python3_libcamera_sha256  /tmp/python3-libcamera_${ver}_${arch}.deb' | sha256sum -c -; fi;
   "
 
   # install debs

--- a/deploy/src-tauri/src/pi_hub_provision/build.rs
+++ b/deploy/src-tauri/src/pi_hub_provision/build.rs
@@ -82,6 +82,12 @@ fn resolve_signers(sig_keys: Option<&[SigKey]>) -> Vec<Signer> {
         .map(|key| Signer {
             label: key.name.trim().to_string(),
             github_user: key.github_user.trim().to_string(),
+            fingerprint: key
+                .fingerprint
+                .as_deref()
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(ToOwned::to_owned),
         })
         .collect()
 }
@@ -202,7 +208,7 @@ pub fn run_build_image(app: &AppHandle, run_id: Uuid, req: BuildImageRequest) ->
             sig_keys: req.sig_keys.clone().map(|keys| {
                 keys
                     .into_iter()
-                    .map(|k| SigKey { name: k.name, github_user: k.github_user })
+                    .map(|k| SigKey { name: k.name, github_user: k.github_user, fingerprint: k.fingerprint })
                     .collect()
             }),
             github_token: req.github_token.clone().filter(|v| !v.trim().is_empty()),

--- a/deploy/src-tauri/src/pi_hub_provision/model.rs
+++ b/deploy/src-tauri/src/pi_hub_provision/model.rs
@@ -53,6 +53,8 @@ pub(crate) struct Wifi {
 pub(crate) struct SigKey {
   pub name: String,
   pub github_user: String,
+  #[serde(default)]
+  pub fingerprint: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]

--- a/deploy/src-tauri/src/provision_server/provision.rs
+++ b/deploy/src-tauri/src/provision_server/provision.rs
@@ -57,6 +57,12 @@ fn resolve_signers(sig_keys: &[crate::provision_server::types::SigKey]) -> Vec<S
     .map(|key| Signer {
       label: key.name.trim().to_string(),
       github_user: key.github_user.trim().to_string(),
+      fingerprint: key
+        .fingerprint
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToOwned::to_owned),
     })
     .collect()
 }
@@ -245,6 +251,12 @@ pub fn run_provision(app: &AppHandle, run_id: Uuid, target: SshTarget, plan: Ser
           .map(|k| crate::pi_hub_provision::model::SigKey {
             name: k.name.trim().to_string(),
             github_user: k.github_user.trim().to_string(),
+            fingerprint: k
+              .fingerprint
+              .as_deref()
+              .map(str::trim)
+              .filter(|v| !v.is_empty())
+              .map(ToOwned::to_owned),
           })
           .collect::<Vec<_>>()
       });
@@ -321,7 +333,14 @@ pub fn run_provision(app: &AppHandle, run_id: Uuid, target: SshTarget, plan: Ser
         "SIG_KEYS",
         sig_keys
           .iter()
-          .map(|k| format!("{}:{}", k.name.trim(), k.github_user.trim()))
+          .map(|k| {
+            let mut value = format!("{}:{}", k.name.trim(), k.github_user.trim());
+            if let Some(fingerprint) = k.fingerprint.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+              value.push(':');
+              value.push_str(fingerprint);
+            }
+            value
+          })
           .filter(|v| !v.trim().is_empty())
           .collect::<Vec<_>>()
           .join(","),

--- a/deploy/src-tauri/src/provision_server/types.rs
+++ b/deploy/src-tauri/src/provision_server/types.rs
@@ -60,6 +60,8 @@ pub struct AutoUpdaterPlan {
 pub struct SigKey {
   pub name: String,
   pub github_user: String,
+  #[serde(default)]
+  pub fingerprint: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/deploy/src/lib/api.ts
+++ b/deploy/src/lib/api.ts
@@ -43,7 +43,7 @@ export interface ServerPlan {
   runtime: ServerRuntimePlan;
   secrets?: { serviceAccountKeyPath: string; serverUrl: string; userCredentialsQrPath: string };
   overwrite?: boolean;
-  sigKeys?: { name: string; githubUser: string }[];
+  sigKeys?: { name: string; githubUser: string; fingerprint?: string }[];
   binariesRepo?: string;
   githubToken?: string;
   manifestVersionOverride?: string;
@@ -81,7 +81,7 @@ export interface ImageBuildRequest {
   sshEnabled?: boolean;
   wifi?: { country: string; ssid: string; psk: string };
   binariesRepo?: string;
-  sigKeys?: { name: string; githubUser: string }[];
+  sigKeys?: { name: string; githubUser: string; fingerprint?: string }[];
   githubToken?: string;
 }
 

--- a/releases/README.md
+++ b/releases/README.md
@@ -37,14 +37,15 @@ Below is a guide instructing how to get everything setup on the VPS and run from
 5. Update the list of available software packages by running `sudo apt-get update`
 6. Install the command line utility jq (used for parsing JSON) by running `apt-get install jq`
 
-The following steps assume you are using version v1.0.0. If we have a release after this and have not updated the version number here, please change the version number accordingly.
-1. Acquire the code from our latest release: `wget https://github.com/secluso/secluso/archive/refs/tags/v1.0.0.zip` 
-2. Unzip the zip file `apt install unzip` then `unzip v1.0.0.zip` (unzips into folder secluso-1.0.0) 
-3. Change your directory into the releases folder in the secluso-1.0.0 directory: `cd secluso-1.0.0/releases`
+The following steps assume you are using version v0.1.0. If we have a release after this and have not updated the version number here, please change the version number accordingly.
+1. Acquire the code from our latest release: `wget https://github.com/secluso/secluso/archive/refs/tags/v0.1.0.zip` 
+2. Unzip the zip file `apt install unzip` then `unzip v0.1.0.zip` (unzips into folder secluso-0.1.0) 
+3. Change your directory into the releases folder in the secluso-0.1.0 directory: `cd secluso-0.1.0/releases`
 4. Run the build.sh script: `./build.sh` with your preferred arguments, which are detailed in the description below.
-5. Fetch our latest release's binary/manifest ZIP file via wget, `wget https://github.com/secluso/secluso/releases/download/v1.0.0/secluso-v1.0.0.zip`  
-6. Unzip the zip file: `unzip secluso-v1.0.0.zip -d official-binaries` (unzips into folder official-binaries)
-7. Run the compare check: `./build.sh --compare builds/<TIMESTAMP> official-binaries` (replace <TIMESTAMP> with the run folder that contains `manifest.json` and `artifacts/`)
+5. Fetch our latest release's binary/manifest ZIP file via wget, `wget https://github.com/secluso/secluso/releases/download/v0.1.0/secluso-v0.1.0.zip`  
+6. Verify the zip file: `echo "483a2e347bb0cd895e00c2434576849641097e8574ba6ceceb151e009c64e77b  secluso-v0.1.0.zip" | sha256sum -c -`
+7. Unzip the zip file: `unzip secluso-v0.1.0.zip -d official-binaries` (unzips into folder official-binaries)
+8. Run the compare check: `./build.sh --compare builds/<TIMESTAMP> official-binaries` (replace <TIMESTAMP> with the run folder that contains `manifest.json` and `artifacts/`)
 
 If you see `REPRODUCIBILITY CHECK PASSED`, then you're all set! We do not recommend casually building with this in case your server is compromised, we only recommend using it as a verification against our released binaries.
 </details>

--- a/releases/lib/plan.bash
+++ b/releases/lib/plan.bash
@@ -173,7 +173,7 @@ setup_builder_if_needed() {
   docker buildx create \
     --name "$BUILDER" \
     --driver docker-container \
-    --driver-opt image=moby/buildkit:v0.23.0 \
+    --driver-opt image=docker.io/moby/buildkit@sha256:a38cf64aa6415899097fac5bfcf6c07c95d5a68c67a21e3d254ba398a3c9187f \
     --use >/dev/null
 
   cleanup_builder() {

--- a/update/src/lib.rs
+++ b/update/src/lib.rs
@@ -38,14 +38,19 @@ pub const NUM_USERNAME_CHARS: usize = 14;
 pub const NUM_PASSWORD_CHARS: usize = 14;
 
 /// A signer entry: label controls signature filename, github_user controls accepted keyring source.
+///Fingerprint (optionally in developer mode) pins trust to one exact OpenPGP primary key
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Signer {
     pub label: String,
     pub github_user: String,
+    pub fingerprint: Option<String>,
 }
 
 /// Primary use point here two signatures, two github contributors, two different keys.
-const DEFAULT_SIGNERS: [(&str, &str); 2] = [("jkaczman", "jkaczman"), ("arrdalan", "arrdalan")];
+const DEFAULT_SIGNERS: [(&str, &str, &str); 2] = [
+    ("jkaczman", "jkaczman", "7785755F1A24FF04CE0E12575DF5E79230C57C4A"),
+    ("arrdalan", "arrdalan", "1A9A1BA3090FA78E946DC0C0301497925DCCE876"),
+];
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct GhRelease {
@@ -199,34 +204,46 @@ impl Component {
 pub fn default_signers() -> Vec<Signer> {
     DEFAULT_SIGNERS
         .iter()
-        .map(|(label, github_user)| Signer {
+        .map(|(label, github_user, fingerprint)| Signer {
             label: (*label).to_string(),
             github_user: (*github_user).to_string(),
+            fingerprint: Some((*fingerprint).to_string()),
         })
         .collect()
 }
 
 // Signer inputs are user-facing configuration, therefore intentionally strict parsing is used. We require
-// NAME:GITHUB_USER format with both fields present... any ambiguity here would weaken signature
+// NAME:GITHUB_USER[:FINGERPRINT] format with the first two fields present... any ambiguity here would weaken signature
 // file lookup and GitHub keyring binding later in the verification pipeline.
 pub fn parse_sig_keys(values: &[String]) -> Result<Vec<Signer>> {
     let mut signers = Vec::with_capacity(values.len());
     for raw in values {
-        let mut parts = raw.splitn(2, ':');
+        let mut parts = raw.splitn(3, ':');
         let label = parts.next().unwrap_or("").trim();
         let github_user = parts.next().unwrap_or("").trim();
+        let fingerprint = parts.next().map(str::trim).filter(|v| !v.is_empty());
         if label.is_empty() || github_user.is_empty() {
             bail!(
-                "Invalid --sig-key value {}. Expected NAME:GITHUB_USER with both parts non-empty.",
+                "Invalid --sig-key value {}. Expected NAME:GITHUB_USER[:FINGERPRINT] with NAME and GITHUB_USER non-empty.",
                 raw
             );
         }
         signers.push(Signer {
             label: label.to_string(),
             github_user: github_user.to_string(),
+            fingerprint: fingerprint
+                .map(normalize_signer_fingerprint)
+                .transpose()
+                .with_context(|| format!("Invalid signer fingerprint in --sig-key {}", raw))?,
         });
     }
     Ok(signers)
+}
+
+fn normalize_signer_fingerprint(raw: &str) -> Result<String> {
+    Ok(Fingerprint::from_hex(raw)
+        .with_context(|| format!("invalid OpenPGP fingerprint {}", raw))?
+        .to_hex())
 }
 
 // We allow either environment variable name in case of a future change in the env variable used to secluso only
@@ -373,13 +390,34 @@ fn download_and_verify_component_with_key_base(
     let mut key_cache: HashMap<String, (Vec<Cert>, HashSet<Fingerprint>)> = HashMap::new();
 
     for (signer, sig_bytes) in &sigs {
-        let (certs, allowed_fprs) = match key_cache.get(&signer.github_user) {
+        let (certs, fetched_fprs) = match key_cache.get(&signer.github_user) {
             Some(v) => v.clone(),
             None => {
                 let v = fetch_github_user_keyring(client, &signer.github_user, key_base_url)?;
                 key_cache.insert(signer.github_user.clone(), v.clone());
                 v
             }
+        };
+        let allowed_fprs = if let Some(required_fpr_hex) = signer.fingerprint.as_deref() {
+            let required_fpr = Fingerprint::from_hex(required_fpr_hex).with_context(|| {
+                format!(
+                    "configured signer fingerprint is invalid (label={}, github_user={})",
+                    signer.label, signer.github_user
+                )
+            })?;
+
+            if !fetched_fprs.contains(&required_fpr) {
+                bail!(
+                    "Configured fingerprint {} was not found in {}'s GitHub keyring (label={})",
+                    required_fpr.to_hex(),
+                    signer.github_user,
+                    signer.label
+                );
+            }
+
+            HashSet::from([required_fpr])
+        } else {
+            fetched_fprs
         };
 
         verify_manifest_sig_requires_user(
@@ -392,8 +430,10 @@ fn download_and_verify_component_with_key_base(
         )
         .with_context(|| {
             format!(
-                "Signature verification failed (label={}, github_user={})",
-                signer.label, signer.github_user
+                "Signature verification failed (label={}, github_user={}, fingerprint={})",
+                signer.label,
+                signer.github_user,
+                signer.fingerprint.as_deref().unwrap_or("<any>")
             )
         })?;
     }

--- a/update/src/main.rs
+++ b/update/src/main.rs
@@ -23,7 +23,8 @@ const USAGE: &str = r#"
 Secluso updater.
 
 Usage:
-  secluso-update --component COMPONENT [--once] [--bundle-path PATH] [--interval-secs N] [--github-timeout-secs N] [--restart-unit UNIT] [--github-repo <OWNER/REPO>] [--sig-key <NAME:GITHUB_USER>]... [--update-hint-path PATH] [--hint-check-interval-secs N]
+  secluso-update --component COMPONENT [--once] [--bundle-path PATH] [--interval-secs N] [--github-timeout-secs N] [--restart-unit UNIT] [--github-repo <OWNER/REPO>] [--sig-key <NAME:GITHUB_USER[:FINGERPRINT]>]...
+  secluso-update --component COMPONENT [--once] [--bundle-path PATH] [--interval-secs N] [--github-timeout-secs N] [--restart-unit UNIT] [--github-repo <OWNER/REPO>] [--sig-key <NAME:GITHUB_USER[:FINGERPRINT]>]... [--update-hint-path PATH] [--hint-check-interval-secs N]
   secluso-update (--help | -h)
   secluso-update (--version | -v)
 
@@ -35,7 +36,7 @@ Options:
   --interval-secs N             Poll interval seconds [default: 60].
   --github-timeout-secs N       HTTP timeout seconds [default: 20].
   --github-repo <OWNER/REPO>    GitHub repo to poll for releases [default: secluso/secluso].
-  --sig-key <NAME:GITHUB_USER>  Signature label + GitHub user (repeatable).
+  --sig-key <NAME:GITHUB_USER[:FINGERPRINT]>  Signature label + GitHub user, with optional pinned fingerprint (repeatable).
   --once                        Run a single update check then exit.
   --bundle-path PATH            Use a local bundle zip instead of downloading from GitHub.
   --update-hint-path PATH       Path for the local update hint file (optional).


### PR DESCRIPTION
[1] We were pulling the Raspberry Pi OS base image and libcamera .deb files and using them immediately without any integrity check. Now both get SHA256-verified.

[2] Builder images are now pinned by digest instead of mutable tags.

[3] I swapped the libcamera mirror over to archive.raspberrypi.com. The previous mirror no longer holds the necessary artifact we're using, which is what necessitated this change.

[4] The updater now requires an exact OpenPGP fingerprint match instead of blindly trusting whatever key a GitHub profile is currently publishing. Key rotations must be pushed to main and re-signed by both of our release keys.

[5] There's also now an integrity check step in the reproducibility README before unzipping the release ZIP. 