### PR TITLE
Deploy Tool: fix Windows SSH keyfile authentication, add image download progress bar, fix listener-attach race

### DIFF
--- a/deploy/src-tauri/Cargo.toml
+++ b/deploy/src-tauri/Cargo.toml
@@ -58,11 +58,15 @@ dirs = "6"
 
 # macOS: vendored OpenSSL avoids host/pkg-config discovery issues when building
 # x86_64-apple-darwin on Apple Silicon hosts.
-
-# non-macOS: default ssh2 avoids vendored OpenSSL Windows cross-build failures
-# in our Linux cargo-xwin builders.
 [target.'cfg(target_os = "macos")'.dependencies]
 ssh2 = { version = "0.9", features = ["vendored-openssl"] }
 
-[target.'cfg(not(target_os = "macos"))'.dependencies]
+# WinCNG cannot use Ed25519 / OpenSSH-format keys, which is what key_gen produces, so keyfile auth fails without this
+# The Windows cross-build cannot vendor-build OpenSSL (VC-WIN64A's Configure rejects a Linux Perl), so releases/Dockerfile.deploy supplies a hash-pinned prebuilt Windows OpenSSL via the OPENSSL_.. env vars instead.
+# We need the openssl-on-win32 feature to make libssh2 use WinCNG.
+[target.'cfg(target_os = "windows")'.dependencies]
+ssh2 = { version = "0.9", features = ["openssl-on-win32"] }
+
+# linux links system libssl-dev for OpenSSL.
+[target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
 ssh2 = "0.9"

--- a/deploy/src-tauri/src/lib.rs
+++ b/deploy/src-tauri/src/lib.rs
@@ -11,8 +11,10 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .manage(pi_hub_provision::PendingRuns::default())
         .invoke_handler(tauri::generate_handler![
             pi_hub_provision::prepare_image,
+            pi_hub_provision::begin_run,
             pi_hub_provision::generate_user_credentials,
             open_external::open_external_url,
             release_config::get_deploy_version_status,

--- a/deploy/src-tauri/src/pi_hub_provision/events.rs
+++ b/deploy/src-tauri/src/pi_hub_provision/events.rs
@@ -34,6 +34,15 @@ pub enum ProvisionEvent {
     message: String,
   },
 
+  #[serde(rename = "progress")]
+  Progress {
+    run_id: Uuid,
+    step: String,
+    downloaded: u64,
+    total: Option<u64>,
+    percent: Option<u8>,
+  },
+
   #[serde(rename = "done")]
   Done {
     run_id: Uuid,
@@ -74,6 +83,20 @@ pub fn step_error(app: &AppHandle, run_id: Uuid, step: &str, msg: impl Into<Stri
       run_id,
       step: step.to_string(),
       message: msg.into(),
+    },
+  );
+}
+
+pub fn progress(app: &AppHandle, run_id: Uuid, step: &str, downloaded: u64, total: Option<u64>) {
+  let percent = total.and_then(|t| (t > 0).then(|| (downloaded.min(t) * 100 / t) as u8));
+  emit(
+    app,
+    ProvisionEvent::Progress {
+      run_id,
+      step: step.to_string(),
+      downloaded,
+      total,
+      percent,
     },
   );
 }

--- a/deploy/src-tauri/src/pi_hub_provision/mod.rs
+++ b/deploy/src-tauri/src/pi_hub_provision/mod.rs
@@ -13,9 +13,11 @@ use crate::pi_hub_provision::prepare::run_prepare_image;
 use crate::pi_hub_provision::temp::shared_temp_dir;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use tauri::AppHandle;
+use std::sync::Mutex;
+use tauri::{AppHandle, State};
 use uuid::Uuid;
 
 // api wiring for tauri commands
@@ -42,6 +44,12 @@ pub struct PrepareImageResponse {
 pub struct BuildStart {
     pub run_id: Uuid,
 }
+
+// Holds a prepared run between prepare_image (registers it) and begin_run (starts it)
+// lets the status page attach its event listener before any events are emitted..
+// essentially this fixes a listener-attach race
+#[derive(Default)]
+pub struct PendingRuns(pub Mutex<HashMap<Uuid, PrepareImageRequest>>);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -103,12 +111,34 @@ pub async fn generate_user_credentials(
     .map_err(err_to_string)
 }
 
+// register the run and hand back its id.
 #[tauri::command]
 pub async fn prepare_image(
-    app: AppHandle,
+    pending: State<'_, PendingRuns>,
     req: PrepareImageRequest,
 ) -> std::result::Result<BuildStart, String> {
     let run_id = Uuid::new_v4();
+    pending
+        .0
+        .lock()
+        .map_err(|_| "pending-runs lock poisoned".to_string())?
+        .insert(run_id, req);
+    Ok(BuildStart { run_id })
+}
+
+// called once the listener is attached
+#[tauri::command]
+pub async fn begin_run(
+    app: AppHandle,
+    pending: State<'_, PendingRuns>,
+    run_id: Uuid,
+) -> std::result::Result<(), String> {
+    let req = pending
+        .0
+        .lock()
+        .map_err(|_| "pending-runs lock poisoned".to_string())?
+        .remove(&run_id)
+        .ok_or_else(|| "unknown or already-started run".to_string())?;
     let app2 = app.clone();
 
     tokio::task::spawn_blocking(move || match run_prepare_image(&app2, run_id, req) {
@@ -128,7 +158,7 @@ pub async fn prepare_image(
         }
     });
 
-    Ok(BuildStart { run_id })
+    Ok(())
 }
 
 fn err_to_string(e: anyhow::Error) -> String {

--- a/deploy/src-tauri/src/pi_hub_provision/prepare.rs
+++ b/deploy/src-tauri/src/pi_hub_provision/prepare.rs
@@ -1,6 +1,6 @@
 //! SPDX-License-Identifier: GPL-3.0-or-later
 use crate::pi_hub_provision::credentials::generate_secluso_credentials;
-use crate::pi_hub_provision::events::{log_line, step_error, step_ok, step_start};
+use crate::pi_hub_provision::events::{log_line, progress, step_error, step_ok, step_start};
 use crate::pi_hub_provision::image_inject::{inject_files, ConstructedFile};
 use crate::pi_hub_provision::model::SigKey;
 use crate::pi_hub_provision::temp::shared_temp_dir;
@@ -17,6 +17,8 @@ use tauri::AppHandle;
 use uuid::Uuid;
 
 fn download_verified_image(
+    app: &AppHandle,
+    run_id: Uuid,
     owner_repo: &str,
     owner_repo_os: &str,
     sig_keys: Option<&[SigKey]>,
@@ -34,6 +36,9 @@ fn download_verified_image(
     let release_actual = fetch_latest_release(&client, owner_repo_os)
         .with_context(|| format!("Fetching latest release metadata for {owner_repo}"))?;
     let asset_name = format!("secluso-pi-image-{}.wic", release.tag_name);
+    let on_progress = |downloaded: u64, total: Option<u64>| {
+        progress(app, run_id, "image_download", downloaded, total);
+    };
     let verified = download_and_verify_release_asset_to_path(
         &client,
         &release,
@@ -41,6 +46,7 @@ fn download_verified_image(
         &asset_name,
         output_path,
         &signers,
+        Some(&on_progress),
     )
     .with_context(|| format!("Downloading and verifying {}", asset_name))?;
 
@@ -201,7 +207,7 @@ pub fn run_prepare_image(
         );
         // Fetch the latest immutable GitHub release metadata, derives the expected WIC asset name from the tag, verifies the signed release checksum file, and streams the WIC to the requested output path
         let (release_tag, image_asset_name) =
-            download_verified_image(&repo, &repo_os, sig_keys, github_token, &output_path).map_err(|e| {
+            download_verified_image(app, run_id, &repo, &repo_os, sig_keys, github_token, &output_path).map_err(|e| {
                 let msg = format!("{e:#}");
                 step_error(app, run_id, "image_download", &msg);
                 anyhow!(msg)

--- a/deploy/src/lib/api.ts
+++ b/deploy/src/lib/api.ts
@@ -58,6 +58,7 @@ export type ProvisionEvent =
   | { type: "step_ok"; run_id: string; step: string }
   | { type: "step_error"; run_id: string; step: string; message: string }
   | { type: "log"; run_id: string; level: "info" | "warn" | "error"; step?: string; line: string }
+  | { type: "progress"; run_id: string; step: string; downloaded: number; total: number | null; percent: number | null }
   | { type: "done"; run_id: string; ok: boolean };
 
 export interface PrepareImageRequest {
@@ -131,6 +132,11 @@ export async function provisionServer(
 
 export async function prepareImage(req: PrepareImageRequest): Promise<JobStart> {
   return invoke("prepare_image", { req });
+}
+
+// Starts the pipeline for a run registered by prepareImage
+export async function beginRun(runId: string): Promise<void> {
+  await invoke("begin_run", { runId });
 }
 
 export async function openExternalUrl(url: string): Promise<void> {

--- a/deploy/src/routes/server-ssh/+page.svelte
+++ b/deploy/src/routes/server-ssh/+page.svelte
@@ -819,7 +819,7 @@
       <div class="modal">
         <div class="modal-title" id="keygen-prompt-title">Set a passphrase for the new key?</div>
         <div class="modal-body">
-          A passphrase protects the private key file on disk — anyone with the file still
+          A passphrase protects the private key file on disk: anyone with the file still
           needs the passphrase to use it. Leave both fields blank for an unprotected key.
         </div>
         <label class="field">
@@ -1836,6 +1836,7 @@
     display: flex;
     justify-content: flex-end;
     gap: 10px;
+    margin-top: 18px;
   }
 
   .modal-confirm {

--- a/deploy/src/routes/status/+page.svelte
+++ b/deploy/src/routes/status/+page.svelte
@@ -3,7 +3,7 @@
   import { onDestroy, onMount } from "svelte";
   import { page } from "$app/stores";
   import { goto } from "$app/navigation";
-  import { listenProvisionEvents, type ProvisionEvent } from "$lib/api";
+  import { listenProvisionEvents, beginRun, type ProvisionEvent } from "$lib/api";
   import { maskDemoText } from "$lib/demoDisplay";
 
   type StepState = "pending" | "running" | "ok" | "error";
@@ -32,6 +32,7 @@
   let mode = "server";
   let steps: { key: string; title: string }[] = [];
   let stepStatus: Record<string, StepState> = {};
+  let stepProgress: Record<string, number> = {};
   let logs: { level: string; step?: string; line: string; time: string }[] = [];
   let doneOk: boolean | null = null;
   let unlisten: (() => void) | null = null;
@@ -89,6 +90,7 @@
 
   function resetState() {
     stepStatus = {};
+    stepProgress = {};
     for (const s of steps) stepStatus[s.key] = "pending";
     if (steps.some((s) => s.key === "validate")) {
       stepStatus = { ...stepStatus, validate: "ok" };
@@ -102,6 +104,18 @@
   async function startListening() {
     if (unlisten) unlisten();
     unlisten = await listenProvisionEvents((evt) => handleEvent(evt));
+    // Listener is attached now. Safe to start the image pipeline.
+    if (mode === "image" && runId) {
+      try {
+        await beginRun(runId);
+      } catch (e) {
+        logs = [
+          ...logs,
+          { level: "error", step: "fatal", line: String(e), time: new Date().toLocaleTimeString() }
+        ];
+        doneOk = false;
+      }
+    }
   }
 
   function handleEvent(evt: ProvisionEvent) {
@@ -124,6 +138,13 @@
         ...logs,
         { level: "error", step: evt.step, line: evt.message, time: new Date().toLocaleTimeString() }
       ];
+      return;
+    }
+
+    if (evt.type === "progress") {
+      if (evt.percent !== null && evt.percent !== undefined) {
+        stepProgress = { ...stepProgress, [evt.step]: evt.percent };
+      }
       return;
     }
 
@@ -380,7 +401,16 @@
             {/if}
 
             <span class="step-title">{s.title}</span>
-            <span class={`step-state ${stepStatus[s.key]}`}>{stepStateLabel(stepStatus[s.key])}</span>
+            <span class={`step-state ${stepStatus[s.key]}`}>
+              {stepStatus[s.key] === "running" && stepProgress[s.key] != null
+                ? `${stepProgress[s.key]}%`
+                : stepStateLabel(stepStatus[s.key])}
+            </span>
+            {#if stepStatus[s.key] === "running" && stepProgress[s.key] != null}
+              <div class="step-progress">
+                <div class="step-progress-fill" style={`width:${stepProgress[s.key]}%;`}></div>
+              </div>
+            {/if}
           </div>
         {/each}
       </section>
@@ -746,6 +776,21 @@
   .step.running .step-title,
   .step.error .step-title {
     color: rgba(255, 255, 255, 0.6);
+  }
+
+  .step-progress {
+    grid-column: 1 / -1;
+    height: 4px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.05);
+    overflow: hidden;
+  }
+
+  .step-progress-fill {
+    height: 100%;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #3b82f6 0%, #60a5fa 50%, #3b82f6 100%);
+    transition: width 140ms ease;
   }
 
   .step-state {

--- a/releases/Dockerfile.deploy
+++ b/releases/Dockerfile.deploy
@@ -9,6 +9,10 @@ ARG PNPM_TARBALL_INTEGRITY
 ARG TAURI_BUNDLE_TARGETS_JSON='["appimage","deb","rpm"]'
 ARG SOURCE_DATE_EPOCH="1704067200"
 ARG DEBUG="0"
+# ATTN; TODO: replace with russh [https://github.com/Eugeny/russh] to get rid of OpenSSL
+# Prebuilt Windows OpenSSL for the cargo-xwin cross-build only.
+ARG FIREDAEMON_OPENSSL_URL="https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.6.2.zip"
+ARG FIREDAEMON_OPENSSL_SHA256="6c64db10cbdd8c0c50c684d07a746f01ac87f0b11292d399ad35880847c8f960"
 
 FROM docker.io/rust@sha256:${RUST_HASH} AS builder
 
@@ -20,6 +24,8 @@ ARG PNPM_TARBALL_INTEGRITY
 ARG TAURI_BUNDLE_TARGETS_JSON
 ARG SOURCE_DATE_EPOCH
 ARG DEBUG
+ARG FIREDAEMON_OPENSSL_URL
+ARG FIREDAEMON_OPENSSL_SHA256
 
 WORKDIR /app
 
@@ -89,10 +95,52 @@ ENV DEBUG=${DEBUG}
 ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 ENV RUST_LOG=tauri_bundler=info,tauri_cli_node=info,ureq=warn
 
+# openssl-sys discovery for the Windows cross-build (only)
+ENV X86_64_PC_WINDOWS_MSVC_OPENSSL_DIR=/opt/win-openssl/x64
+ENV X86_64_PC_WINDOWS_MSVC_OPENSSL_STATIC=1
+ENV X86_64_PC_WINDOWS_MSVC_OPENSSL_NO_VENDOR=1
+ENV AARCH64_PC_WINDOWS_MSVC_OPENSSL_DIR=/opt/win-openssl/arm64
+ENV AARCH64_PC_WINDOWS_MSVC_OPENSSL_STATIC=1
+ENV AARCH64_PC_WINDOWS_MSVC_OPENSSL_NO_VENDOR=1
+
 RUN /opt/secluso-docker-deploy/setup_linuxdeploy_plugins.bash
 RUN pnpm install --frozen-lockfile
 RUN rustup target add ${TAURI_TARGET}
 RUN if [ "${TAURI_RUNNER}" = "cargo-xwin" ]; then cargo install --locked cargo-xwin --version ${CARGO_XWIN_VERSION}; fi
+
+# Pre built Windows OpenSSL
+RUN set -eux; \
+    if [ "${TAURI_RUNNER}" = "cargo-xwin" ]; then \
+      : "${FIREDAEMON_OPENSSL_URL:?missing FIREDAEMON_OPENSSL_URL build arg}"; \
+      : "${FIREDAEMON_OPENSSL_SHA256:?missing FIREDAEMON_OPENSSL_SHA256 build arg}"; \
+      zip="/tmp/firedaemon-openssl.zip"; \
+      curl -fsSL --retry 8 --retry-delay 2 --retry-all-errors --connect-timeout 20 \
+        "${FIREDAEMON_OPENSSL_URL}" -o "${zip}"; \
+      echo "${FIREDAEMON_OPENSSL_SHA256}  ${zip}" | sha256sum -c -; \
+      tmp="$(mktemp -d)"; \
+      unzip -q "${zip}" -d "${tmp}"; \
+      rm -f "${zip}"; \
+      for arch in x64 arm64; do \
+        src="$(dirname "$(find "${tmp}" -type d -path "*/${arch}/include/openssl" -print -quit)")"; \
+        if [ -z "${src}" ] || [ ! -d "${src}" ]; then \
+          echo "FireDaemon OpenSSL: ${arch} include dir not found in archive" >&2; exit 1; \
+        fi; \
+        src="$(dirname "${src}")"; \
+        dst="/opt/win-openssl/${arch}"; \
+        mkdir -p "${dst}"; \
+        cp -a "${src}/." "${dst}/"; \
+        # stage the FireDaemon runtime DLLs into the project for the Windows bundle to install next to the exe
+        rt="/app/deploy/src-tauri/openssl-runtime/${arch}"; \
+        mkdir -p "${rt}"; \
+        cp -f "${dst}"/bin/libcrypto-3-*.dll "${dst}"/bin/libssl-3-*.dll "${rt}/"; \
+        touch -d "@${SOURCE_DATE_EPOCH}" "${rt}"/*.dll; \
+      done; \
+      rm -rf "${tmp}"; \
+      ls -la /opt/win-openssl/x64/lib /app/deploy/src-tauri/openssl-runtime/x64; \
+    else \
+      echo "Not a cargo-xwin build (TAURI_RUNNER=${TAURI_RUNNER}); skipping prebuilt OpenSSL."; \
+    fi
+
 RUN /opt/secluso-docker-deploy/run_tauri_build.bash
 
 FROM scratch AS artifact

--- a/releases/lib/docker_deploy/run_tauri_build.bash
+++ b/releases/lib/docker_deploy/run_tauri_build.bash
@@ -88,7 +88,22 @@ configure_rust_log() {
 }
 
 write_bundle_config() {
-  printf '{ "bundle": { "targets": %s } }\n' "${TAURI_BUNDLE_TARGETS_JSON}" > /tmp/tauri-bundle-config.json
+  local resources=""
+  if [[ "$TAURI_TARGET" == *"-pc-windows-"* ]]; then
+    # FireDaemon OpenSSL is DLL-only
+    # put libcrypto/libssl next to the exe so  libssh2's OpenSSL backend loads at runtime.
+    local arch="x64"
+    [[ "$TAURI_TARGET" == aarch64-* ]] && arch="arm64"
+    local rdir="/app/deploy/src-tauri/openssl-runtime/${arch}"
+    local map="" f bn
+    for f in "$rdir"/*.dll; do
+      [[ -e "$f" ]] || continue
+      bn="$(basename "$f")"
+      map+="${map:+, }\"openssl-runtime/${arch}/${bn}\": \"${bn}\""
+    done
+    [[ -n "$map" ]] && resources=", \"resources\": { ${map} }"
+  fi
+  printf '{ "bundle": { "targets": %s%s } }\n' "${TAURI_BUNDLE_TARGETS_JSON}" "${resources}" > /tmp/tauri-bundle-config.json
   echo "==> tauri bundle config"
   cat /tmp/tauri-bundle-config.json
 }

--- a/update/src/lib.rs
+++ b/update/src/lib.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{Cursor, Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use zip::ZipArchive;
 
 use openpgp::cert::Cert;
@@ -344,6 +344,7 @@ pub fn download_and_verify_release_asset_to_path(
     asset_name: &str,
     output_path: &Path,
     signers: &[Signer],
+    progress: Option<&dyn Fn(u64, Option<u64>)>,
 ) -> Result<VerifiedReleaseFile> {
     download_and_verify_release_asset_to_path_with_key_base(
         client,
@@ -353,6 +354,7 @@ pub fn download_and_verify_release_asset_to_path(
         output_path,
         signers,
         "https://github.com",
+        progress,
     )
 }
 
@@ -364,6 +366,7 @@ fn download_and_verify_release_asset_to_path_with_key_base(
     output_path: &Path,
     signers: &[Signer],
     key_base_url: &str,
+    progress: Option<&dyn Fn(u64, Option<u64>)>,
 ) -> Result<VerifiedReleaseFile> {
     require_release_is_immutable(release)?;
     // ensure that immutability is enforced in the OS repo as well
@@ -394,7 +397,7 @@ fn download_and_verify_release_asset_to_path_with_key_base(
 
     // Large release assets are streamed to disk while hashing so the deploy tool can verify WIC images without keeping the whole image in memory.
     // The resulting hash is compared against the signed checksum entry after GitHub's own asset digest metadata has also been checked
-    let got = download_asset_to_path_and_hash(client, &asset, output_path)
+    let got = download_asset_to_path_and_hash(client, &asset, output_path, progress)
         .with_context(|| format!("Downloading {}", asset.name))?;
 
     if expected != &got {
@@ -624,6 +627,7 @@ fn download_asset_to_path_and_hash(
     client: &Client,
     asset: &GhAsset,
     output_path: &Path,
+    progress: Option<&dyn Fn(u64, Option<u64>)>,
 ) -> Result<String> {
     // This is for large release assets where loading the entire file into memory isn't ideal
     // Streams bytes from GitHub to the requested output file, updates a SHA-256 hasher with the exact bytes written, fsyncs the result, and deletes the output on digest mismatch
@@ -657,6 +661,14 @@ fn download_asset_to_path_and_hash(
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 1024 * 128];
 
+    // Total may be absent if the server omits Content-Length
+    let total = resp.content_length();
+    let mut downloaded: u64 = 0;
+    let mut last_report = Instant::now();
+    if let Some(cb) = progress {
+        cb(0, total);
+    }
+
     loop {
         let n = resp
             .read(&mut buf)
@@ -667,6 +679,17 @@ fn download_asset_to_path_and_hash(
         out.write_all(&buf[..n])
             .with_context(|| format!("writing {}", output_path.display()))?;
         hasher.update(&buf[..n]);
+        downloaded += n as u64;
+        // Throttle so it doesn't flood the event channel.
+        if let Some(cb) = progress {
+            if last_report.elapsed() >= Duration::from_millis(200) {
+                cb(downloaded, total);
+                last_report = Instant::now();
+            }
+        }
+    }
+    if let Some(cb) = progress {
+        cb(downloaded, total);
     }
     out.sync_all()
         .with_context(|| format!("syncing {}", output_path.display()))?;


### PR DESCRIPTION
[1] Windows SSH keyfile authentication fix. The newly introduced keyfile auth was failing only on Windows because libssh2 used the [WinCNG backend](https://github.com/libssh2/libssh2/blob/master/src/wincng.h), which can't handle the Ed25519/OpenSSH keys the key generator produces (notice the LIBSSH2_ED25519 macro is set to 0 in the header file). Vendoring OpenSSL is impossible (VC-WIN64A rejects a Linux Perl). The fix that ended up working was enabling the openssl-on-win32 Cargo feature for Windows to use OpenSSL instead of WinCNG. Since it needs a OpenSSL it can't build, Dockerfile.deploy fetches a (SHA-256-pinned) [FireDaemon OpenSSL](https://www.firedaemon.com/firedaemon-openssl) 3.6.2. The build stages the DLLs so they install next to the exe inside the NSIS installer. **Verified the Windows deploy tool is reproducible still with these changes on two different machines.** This is only temporary. The plan soon is to get rid of OpenSSL in the deploy tool entirely through using [russh](https://github.com/Eugeny/russh) instead (see this issue: https://github.com/secluso/core/issues/84)
  
[2] Two changes to the status page, adding a progress bar and fixing a race. 
- The secluso_update crate now reads Content-Length and calls progress callback. This renders a per-step percent and a fill bar in the status page.
- There was an occasional missing "Generate secrets" checkmark. It turned out to be a race where prepare_image started work before the frontend's event listener attached. This is now fixed.
