### PR TITLE
Use Debian archive snapshot to pin apt packages in reproducible builds for runtime binaries and Linux & Windows deploy tool

### DIFF
--- a/releases/Dockerfile
+++ b/releases/Dockerfile
@@ -5,6 +5,8 @@ ARG FEATURES=""
 ARG RUST_HASH="5861091755a3298619c94a6cbf0534062cfeb9afcda9f698a13df3ef64e2dd8b" # Provided as default to quiet docker warning. This is never used (unless separately passed in).
 ARG CARGO_TARGET=""
 ARG BINARY_FILE_NAME=""
+# Debian archive snapshot. Pins every apt package so they don't float when the builder is rebuilt.
+ARG DEBIAN_SNAPSHOT="20260501T000000Z"
 
 # Use a digest-locked Rust image as our builder
 FROM docker.io/rust@sha256:${RUST_HASH} AS builder
@@ -13,8 +15,24 @@ ARG CRATE_NAME
 ARG FEATURES
 ARG CARGO_TARGET
 ARG BINARY_FILE_NAME
+ARG DEBIAN_SNAPSHOT
 
 WORKDIR /app
+
+# Repoint apt at the pinned Debian snapshot before any update/install.
+RUN set -eux; \
+    : "${DEBIAN_SNAPSHOT:?missing DEBIAN_SNAPSHOT build arg}"; \
+    codename="$(. /etc/os-release && echo "$VERSION_CODENAME")"; \
+    snap="https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}"; \
+    snap_sec="https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}"; \
+    rm -f /etc/apt/sources.list.d/debian.sources; \
+    { \
+      echo "deb ${snap}/ ${codename} main"; \
+      echo "deb ${snap}/ ${codename}-updates main"; \
+      echo "deb ${snap_sec}/ ${codename}-security main"; \
+    } > /etc/apt/sources.list; \
+    printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "8";\n' \
+      > /etc/apt/apt.conf.d/99snapshot
 
 # Install build deps for crates that rely on system crypto libs (e.g., nettle-sys).
 RUN set -eux; \

--- a/releases/Dockerfile.deploy
+++ b/releases/Dockerfile.deploy
@@ -13,6 +13,8 @@ ARG DEBUG="0"
 # Prebuilt Windows OpenSSL for the cargo-xwin cross-build only.
 ARG FIREDAEMON_OPENSSL_URL="https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.6.2.zip"
 ARG FIREDAEMON_OPENSSL_SHA256="6c64db10cbdd8c0c50c684d07a746f01ac87f0b11292d399ad35880847c8f960"
+# Debian archive snapshot. Pins every apt package so they don't float when the builder is rebuilt.
+ARG DEBIAN_SNAPSHOT="20260501T000000Z"
 
 FROM docker.io/rust@sha256:${RUST_HASH} AS builder
 
@@ -26,8 +28,24 @@ ARG SOURCE_DATE_EPOCH
 ARG DEBUG
 ARG FIREDAEMON_OPENSSL_URL
 ARG FIREDAEMON_OPENSSL_SHA256
+ARG DEBIAN_SNAPSHOT
 
 WORKDIR /app
+
+# Repoint apt at the pinned Debian snapshot before any update/install.
+RUN set -eux; \
+    : "${DEBIAN_SNAPSHOT:?missing DEBIAN_SNAPSHOT build arg}"; \
+    codename="$(. /etc/os-release && echo "$VERSION_CODENAME")"; \
+    snap="https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}"; \
+    snap_sec="https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}"; \
+    rm -f /etc/apt/sources.list.d/debian.sources; \
+    { \
+      echo "deb ${snap}/ ${codename} main"; \
+      echo "deb ${snap}/ ${codename}-updates main"; \
+      echo "deb ${snap_sec}/ ${codename}-security main"; \
+    } > /etc/apt/sources.list; \
+    printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "8";\n' \
+      > /etc/apt/apt.conf.d/99snapshot
 
 RUN set -eux; \
     apt-get update; \


### PR DESCRIPTION
Previously, there was a chance for drift in reproducible builds based on an underlying package fetched from apt getting a newer version than previously built that changed underlying structure in the build. Thus, Debian snapshots are now used to pin the versions for all packages fetched via apt in the builds for the binaries and deploy tool.

https://github.com/secluso/mobile_client/pull/81 was also implemented as the complementary fix for the Android reproducible builds.