### PR TITLE
Don't overwrite AppImage magic hex

### DIFF
--- a/releases/lib/docker_deploy/run_tauri_build.bash
+++ b/releases/lib/docker_deploy/run_tauri_build.bash
@@ -827,9 +827,6 @@ rebuild_appimage_deterministically_in_place() {
     return 1
   }
 
-  perl -e 'print pack("Q<", $ARGV[0]);' "$runtime_size" > "$tmp/runtime-offset.bin"
-  dd if="$tmp/runtime-offset.bin" of="$tmp/runtime" bs=1 seek=8 conv=notrunc status=none
-
   local squash_md5 squash_sha id_hex
   local digest_offset_hex=""
   squash_sha="$(sha256sum "$tmp/payload.squashfs" 2>/dev/null | awk '{print $1}' || true)"


### PR DESCRIPTION
The deterministic AppImage Deploy Tool build created by the reproducible build release script has an incorrect header that does not conform to the [AppImage Specification Type 2 image format](https://github.com/AppImage/AppImageSpec/blob/74ad9ca2f94bf864a4a0dac1f369dd4f00bd1c28/draft.md). The magic hex needs to match what they've outlined in that specification (and discussed in the below GitHub issue).

<img width="453" height="536" alt="Screenshot 2026-06-02 at 4 38 06 PM" src="https://github.com/user-attachments/assets/c98e3792-49a4-40c5-9a77-4bd2bbb56a39" />

The way we emit a deterministic AppImage is via a normal build, and then taking it apart and re-building it back together to be deterministic (introduced in https://github.com/secluso/core/commit/e1c692179ec6333a91312a2231b4b6f4a30ea21f). However, when we were putting it back together, we were overwriting the magic hex that's meant to be in the header with the size of the runtime.  Since libappimage is capable of knowing the size of the runtime without us explicitly saying so (as seen below), this is unnecessary and a bug. Removing the overwrite fixes the issue, and correctly maintains the proper magic hex.

<img width="617" height="215" alt="Screenshot 2026-06-02 at 4 37 36 PM" src="https://github.com/user-attachments/assets/bd31005e-a3b8-497e-9d38-5054c1e37cc4" />
<img width="600" height="295" alt="Screenshot 2026-06-02 at 4 37 46 PM" src="https://github.com/user-attachments/assets/0b780678-51a5-41c5-958a-894357dd12ce" />

(https://github.com/AppImage/AppImageKit/blob/master/src/runtime.c, https://github.com/AppImageCommunity/libappimage/blob/f8f106b42911aea53e3fa1618e9198b1bbd3bfc9/src/libappimage/utils/ElfFile.h#L16)

fixes #111 