### PR TITLE
Support IMX708 (Camera Module V3)

### DIFF
--- a/camera_hub/src/raspberry_pi/rpi_camera.rs
+++ b/camera_hub/src/raspberry_pi/rpi_camera.rs
@@ -520,7 +520,7 @@ impl RaspberryPiCamera {
         // Even though these support 1080p directly, if we were to use that, the sides would be cropped out due to the aspect ratio of the sensor.
         const CAMERA_RESOLUTION_V1: (usize, usize) = (1296, 972);
         const CAMERA_RESOLUTION_V2: (usize, usize) = (1640, 1232);
-        const CAMERA_RESOLUTION_V3: (usize, usize) = (2304, 1296);
+        const CAMERA_RESOLUTION_V3: (usize, usize) = (1920, 1080);
 
         // Detection logic to determine if the attached camera module is a V1, V2 or other (which likely won't reach this point as they aren't supported in the Secluso OS image regardless)
         // Sample Output of "rpicam-hello --list-cameras" that we must parse:

--- a/camera_hub/src/raspberry_pi/rpi_camera.rs
+++ b/camera_hub/src/raspberry_pi/rpi_camera.rs
@@ -516,9 +516,11 @@ impl RaspberryPiCamera {
         // Hard coded width x height based on the Camera Module connected to the Raspberry Pi.
         // Camera Module V1 (OV5647): 1296 x 972 (60% of 1080p)
         // Camera Module V2 (IMX219): 1640 x 1232 (97% of 1080p)
+        // Camera Module V3 (IMX708): 2304x1296 (140% of 1080p)
         // Even though these support 1080p directly, if we were to use that, the sides would be cropped out due to the aspect ratio of the sensor.
         const CAMERA_RESOLUTION_V1: (usize, usize) = (1296, 972);
         const CAMERA_RESOLUTION_V2: (usize, usize) = (1640, 1232);
+        const CAMERA_RESOLUTION_V3: (usize, usize) = (2304, 1296);
 
         // Detection logic to determine if the attached camera module is a V1, V2 or other (which likely won't reach this point as they aren't supported in the Secluso OS image regardless)
         // Sample Output of "rpicam-hello --list-cameras" that we must parse:
@@ -534,6 +536,16 @@ impl RaspberryPiCamera {
         //                       1640x1232 [41.85 fps - (0, 0)/3280x2464 crop]
         //                       1920x1080 [47.57 fps - (680, 692)/1920x1080 crop]
         //                       3280x2464 [21.19 fps - (0, 0)/3280x2464 crop]
+
+        /**
+            For IMX708, source: https://forums.raspberrypi.com/viewtopic.php?t=381114
+            Available cameras
+            -----------------
+            0 : imx708_wide_noir [4608x2592 10-bit RGGB] (/base/soc/i2c0mux/i2c@1/imx708@1a)
+                Modes: 'SRGGB10_CSI2P' : 1536x864 [120.13 fps - (768, 432)/3072x1728 crop]
+                                         2304x1296 [56.03 fps - (0, 0)/4608x2592 crop]
+                                         4608x2592 [14.35 fps - (0, 0)/4608x2592 crop]
+        */
 
         let output = Command::new("rpicam-hello")
             .args(["--list-cameras"])
@@ -553,6 +565,11 @@ impl RaspberryPiCamera {
             Some(CameraResolution {
                 width: CAMERA_RESOLUTION_V1.0,
                 height: CAMERA_RESOLUTION_V1.1,
+            })
+        } else if stdout.contains("imx708") {
+            Some(CameraResolution {
+                width: CAMERA_RESOLUTION_V3.0,
+                height: CAMERA_RESOLUTION_V3.1,
             })
         } else {
             None


### PR DESCRIPTION
Adds auto-detection in the camera-hub to check for IMX708 (Camera Module V3) and, if present, accept it with the resolution of 1920 x 1080 (cropped). An uncropped resolution would not be possible without a significant decrease in resolution due to the 1080p 30fps limit imposed by the VideoCore IV GPU ([limitations discussed here](https://github.com/hermanhermitage/videocoreiv/wiki/VideoCore-IV---BCM2835-Overview)).

2304x1296 is over 1080p and thus cannot be used (as seen in the image below):
<img width="647" height="119" alt="Screenshot 2026-06-13 at 11 00 53 AM" src="https://github.com/user-attachments/assets/0fe84612-7b40-4279-acac-02fb1e14e540" />

Pairs with https://github.com/secluso/os/pull/37
Fixes https://github.com/secluso/core/issues/130