### PR TITLE
Honor ROCKET_LOG_LEVEL, add Deploy Tool server verbosity setting

### DIFF
--- a/deploy/src-tauri/assets/server/provision_server.sh
+++ b/deploy/src-tauri/assets/server/provision_server.sh
@@ -135,7 +135,7 @@ WorkingDirectory=$STATE_DIR
 ExecStart=$INSTALL_BIN_DIR/secluso-server --bind-address=${BIND_ADDRESS:-127.0.0.1} --port=${LISTEN_PORT:-8000}
 Restart=always
 RestartSec=1
-Environment=RUST_LOG=info
+Environment=ROCKET_LOG_LEVEL=${ROCKET_LOG_LEVEL:-normal}
 Environment=SECLUSO_USER_CREDENTIALS_DIR=$STATE_DIR/user_credentials
 Environment=UPDATE_HINT_PATH=$STATE_DIR/update_hint
 NoNewPrivileges=true

--- a/deploy/src-tauri/src/provision_server/provision.rs
+++ b/deploy/src-tauri/src/provision_server/provision.rs
@@ -405,6 +405,16 @@ pub fn run_provision(
         {
             envs.push(("GITHUB_TOKEN", token));
         }
+        // Whitelist the Rocket log level
+        // Only allowlisted 3 values to prevent injection
+        if let Some(level) = plan
+            .server_log_level
+            .as_ref()
+            .map(|v| v.trim().to_ascii_lowercase())
+            .filter(|v| matches!(v.as_str(), "off" | "critical" | "debug"))
+        {
+            envs.push(("ROCKET_LOG_LEVEL", level));
+        }
         exec_remote_script_streaming(
             app,
             run_id,

--- a/deploy/src-tauri/src/provision_server/types.rs
+++ b/deploy/src-tauri/src/provision_server/types.rs
@@ -88,4 +88,5 @@ pub struct ServerPlan {
   pub binaries_repo: Option<String>,
   pub github_token: Option<String>,
   pub manifest_version_override: Option<String>,
+  pub server_log_level: Option<String>,
 }

--- a/deploy/src/lib/api.ts
+++ b/deploy/src/lib/api.ts
@@ -47,6 +47,7 @@ export interface ServerPlan {
   binariesRepo?: string;
   githubToken?: string;
   manifestVersionOverride?: string;
+  serverLogLevel?: "normal" | "debug" | "critical" | "off";
 }
 
 export interface JobStart {

--- a/deploy/src/routes/server-ssh/+page.svelte
+++ b/deploy/src/routes/server-ssh/+page.svelte
@@ -60,6 +60,7 @@
     key2User: string;
     githubToken: string;
     manifestVersionOverride: string;
+    serverLogLevel: "normal" | "debug" | "critical" | "off";
     maskUserPathsWithDemo: boolean;
   };
 
@@ -76,6 +77,7 @@
     key2User: "",
     githubToken: "",
     manifestVersionOverride: "",
+    serverLogLevel: "normal",
     maskUserPathsWithDemo: false
   };
   let devSettings: DevSettings | null = null;
@@ -627,6 +629,10 @@
       manifestVersionOverride:
         devSettings?.enabled && devSettings?.manifestVersionOverride.trim()
           ? devSettings.manifestVersionOverride.trim()
+          : undefined,
+      serverLogLevel:
+        devSettings?.enabled && devSettings?.serverLogLevel && devSettings.serverLogLevel !== "normal"
+          ? devSettings.serverLogLevel
           : undefined,
       overwrite: overwriteInstall
     };

--- a/deploy/src/routes/settings/+page.svelte
+++ b/deploy/src/routes/settings/+page.svelte
@@ -17,8 +17,11 @@
     key2User: string;
     githubToken: string;
     manifestVersionOverride: string;
+    serverLogLevel: ServerLogLevel;
     maskUserPathsWithDemo: boolean;
   };
+
+  type ServerLogLevel = "normal" | "debug" | "critical" | "off";
 
   const STORAGE_KEY = "secluso-dev-settings";
   const backIcon = "/deploy-assets/settings-back-latest.svg";
@@ -38,6 +41,7 @@
     key2User: "",
     githubToken: "",
     manifestVersionOverride: "",
+    serverLogLevel: "normal",
     maskUserPathsWithDemo: false
   };
 
@@ -298,6 +302,26 @@
             />
           </label>
           <p>Overrides the version sent in the post-install server health check.</p>
+        </section>
+
+        <section class="option-card token-card">
+          <div class="option-header">
+            <h2>Server Log Level</h2>
+            <span class="badge">OPTIONAL</span>
+          </div>
+
+          <label class="field">
+            <span>Level</span>
+            <select class="select-input" bind:value={devSettings.serverLogLevel}>
+              <option value="normal">normal (default)</option>
+              <option value="debug">debug</option>
+              <option value="critical">critical</option>
+              <option value="off">off</option>
+            </select>
+          </label>
+          <p>
+            Sets <code>ROCKET_LOG_LEVEL</code> in the provisioned server's systemd unit.
+          </p>
         </section>
       </section>
     {/if}
@@ -592,6 +616,25 @@
 
   .field input::placeholder {
     color: rgba(250, 250, 250, 0.5);
+  }
+
+  .select-input {
+    width: 100%;
+    height: 32px;
+    border: 0;
+    outline: 0;
+    padding: 0;
+    background: transparent;
+    color: #fafafa;
+    font-size: 16px;
+    line-height: 24px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
+  .select-input option {
+    background: #0b0b0b;
+    color: #fafafa;
   }
 
   .binaries-card {

--- a/deploy/src/routes/settings/+page.svelte
+++ b/deploy/src/routes/settings/+page.svelte
@@ -619,12 +619,18 @@
   }
 
   .select-input {
+    appearance: none;
+    -webkit-appearance: none;
     width: 100%;
     height: 32px;
-    border: 0;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
     outline: 0;
-    padding: 0;
-    background: transparent;
+    padding: 0 30px 0 10px;
+    background-color: #0b0b0b;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='none' stroke='%23fafafa' stroke-width='1.5' d='M1 1l4 4 4-4'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
     color: #fafafa;
     font-size: 16px;
     line-height: 24px;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1261,10 +1261,17 @@ pub fn build_rocket() -> rocket::Rocket<rocket::Build> {
         }
     });
 
+    // Reflect log levels explicitly as we override the config so operators can raise
+    let log_level = std::env::var("ROCKET_LOG_LEVEL")
+        .ok()
+        .and_then(|v| v.parse::<rocket::config::LogLevel>().ok())
+        .unwrap_or(rocket::Config::default().log_level);
+
     let config = rocket::Config {
         port: listen_port.unwrap_or(8000),
         address: address.parse().unwrap(),
         limits: Limits::default().limit("json", MAX_JSON_SIZE.kibibytes()),
+        log_level,
         ..rocket::Config::default()
     };
 


### PR DESCRIPTION
Adds a setting in the deploy tool that allows the server's verbosity to be set (the env var in the systemd unit) when provisioning a server. Helpful for when needing to debug the server.

Fixed ROCKET_LOG_LEVEL environmental variable not working by explicitly reading it and passing it into Rocket's config.

<img width="915" height="100" alt="Screenshot 2026-06-18 at 7 29 32 AM" src="https://github.com/user-attachments/assets/3fc1f67d-d65a-467b-b4fc-0fa8fb2e767a" />

[Rocket Docs](https://rocket.rs/guide/v0.5/deploying/#fully-managed)